### PR TITLE
Strengthen Zeno experiment reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ uv run pytest
 uv run quantum-lab run examples/free_packet.toml --out runs/free_packet
 uv run quantum-lab run examples/barrier_zeno.toml --out runs/barrier_zeno
 uv run quantum-lab compare examples/zeno_sweep.toml --out reports/zeno_sweep
+uv run quantum-lab compare examples/zeno_research_sweep.toml --out reports/zeno_research_sweep
 uv run quantum-lab render runs/free_packet/run.npz --out reports/free_packet
 ```
 
@@ -33,6 +34,15 @@ Supported v1 experiments:
 
 The maintained implementation lives in `src/quantum_dynamics_lab/`; example
 experiment configs live in `examples/`; tests live in `tests/`.
+
+For Zeno barrier experiments, the maintained workflow now supports optional
+absorbing edge boundaries and explicit detector placement. Repeated
+measurements are modeled as no-click projections: probability in the detector
+region is accumulated as detector-click probability, removed from the
+conditional wavefunction, and the no-click branch is renormalized while
+survival weight tracks the unconditional probability. Generated comparison
+reports include `comparison.csv`, `comparison.png`, `zeno_transmission_heatmap.png`,
+and `report.md`.
 
 ---
 

--- a/examples/barrier_zeno.toml
+++ b/examples/barrier_zeno.toml
@@ -21,10 +21,17 @@ dt = 0.002
 tf = 1.2
 frame_interval = 0.03
 
+[boundary]
+kind = "absorbing"
+width = 1.0
+strength = 4.0
+power = 2.0
+
 [measurement]
 kind = "zeno"
 interval = 0.12
+detector_buffer = 0.25
 
 [output]
 fps = 20
-render_video = true
+render_video = false

--- a/examples/zeno_research_sweep.toml
+++ b/examples/zeno_research_sweep.toml
@@ -1,0 +1,6 @@
+name = "zeno_research_sweep"
+base_config = "barrier_zeno.toml"
+
+[scan]
+potential_heights = [25.0, 40.0, 60.0]
+measurement_intervals = [0.0, 0.24, 0.12, 0.06]

--- a/src/quantum_dynamics_lab/config.py
+++ b/src/quantum_dynamics_lab/config.py
@@ -40,10 +40,20 @@ class SolverConfig:
 
 
 @dataclass(frozen=True)
+class BoundaryConfig:
+    kind: str = "periodic"
+    width: float = 0.0
+    strength: float = 0.0
+    power: float = 2.0
+
+
+@dataclass(frozen=True)
 class MeasurementConfig:
     kind: str = "none"
     interval: float | None = None
     time: float | None = None
+    detector_x: float | None = None
+    detector_buffer: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -60,6 +70,7 @@ class ExperimentConfig:
     wave_packet: WavePacketConfig = field(default_factory=WavePacketConfig)
     potential: PotentialConfig = field(default_factory=PotentialConfig)
     solver: SolverConfig = field(default_factory=SolverConfig)
+    boundary: BoundaryConfig = field(default_factory=BoundaryConfig)
     measurement: MeasurementConfig = field(default_factory=MeasurementConfig)
     output: OutputConfig = field(default_factory=OutputConfig)
 
@@ -72,6 +83,7 @@ class SweepVariant:
     name: str
     measurement_kind: str = "zeno"
     measurement_interval: float | None = None
+    potential_height: float | None = None
 
 
 @dataclass(frozen=True)
@@ -102,6 +114,7 @@ def load_experiment_config(path: str | Path) -> ExperimentConfig:
     wave_data = _section(data, "wave_packet")
     potential_data = _section(data, "potential")
     solver_data = _section(data, "solver")
+    boundary_data = _section(data, "boundary")
     measurement_data = _section(data, "measurement")
     output_data = _section(data, "output")
 
@@ -137,6 +150,12 @@ def load_experiment_config(path: str | Path) -> ExperimentConfig:
         hbar=float(solver_data.get("hbar", SolverConfig.hbar)),
         mass=float(solver_data.get("mass", SolverConfig.mass)),
     )
+    boundary = BoundaryConfig(
+        kind=str(boundary_data.get("kind", BoundaryConfig.kind)),
+        width=float(boundary_data.get("width", BoundaryConfig.width)),
+        strength=float(boundary_data.get("strength", BoundaryConfig.strength)),
+        power=float(boundary_data.get("power", BoundaryConfig.power)),
+    )
     measurement = MeasurementConfig(
         kind=str(measurement_data.get("kind", MeasurementConfig.kind)),
         interval=(
@@ -146,6 +165,14 @@ def load_experiment_config(path: str | Path) -> ExperimentConfig:
         ),
         time=(
             None if measurement_data.get("time") is None else float(measurement_data["time"])
+        ),
+        detector_x=(
+            None
+            if measurement_data.get("detector_x") is None
+            else float(measurement_data["detector_x"])
+        ),
+        detector_buffer=float(
+            measurement_data.get("detector_buffer", MeasurementConfig.detector_buffer)
         ),
     )
     output = OutputConfig(
@@ -159,6 +186,7 @@ def load_experiment_config(path: str | Path) -> ExperimentConfig:
         wave_packet=wave,
         potential=potential,
         solver=solver,
+        boundary=boundary,
         measurement=measurement,
         output=output,
     )
@@ -170,13 +198,33 @@ def load_sweep_config(path: str | Path) -> SweepConfig:
     variants = []
     for item in data.get("variants", []):
         interval = item.get("measurement_interval")
+        height = item.get("potential_height")
         variants.append(
             SweepVariant(
                 name=str(item["name"]),
                 measurement_kind=str(item.get("measurement_kind", "zeno")),
                 measurement_interval=None if interval is None else float(interval),
+                potential_height=None if height is None else float(height),
             )
         )
+    scan = data.get("scan", {})
+    if scan:
+        intervals = [float(value) for value in scan.get("measurement_intervals", [])]
+        heights = [float(value) for value in scan.get("potential_heights", [])]
+        if not intervals:
+            intervals = [0.0]
+        if not heights:
+            heights = [0.0]
+        for height in heights:
+            for interval in intervals:
+                variants.append(
+                    SweepVariant(
+                        name=_scan_variant_name(height, interval),
+                        measurement_kind="none" if interval <= 0 else "zeno",
+                        measurement_interval=None if interval <= 0 else interval,
+                        potential_height=height,
+                    )
+                )
     base_config = Path(str(data["base_config"]))
     if not base_config.is_absolute():
         base_config = path.parent / base_config
@@ -194,4 +242,18 @@ def apply_sweep_variant(config: ExperimentConfig, variant: SweepVariant) -> Expe
         kind = "none"
         interval = None
     measurement = replace(config.measurement, kind=kind, interval=interval)
-    return replace(config, name=variant.name, measurement=measurement)
+    potential = config.potential
+    if variant.potential_height is not None:
+        potential = replace(potential, height=variant.potential_height)
+    return replace(config, name=variant.name, potential=potential, measurement=measurement)
+
+
+def _scan_variant_name(height: float, interval: float) -> str:
+    height_label = _number_label(height)
+    if interval <= 0:
+        return f"h{height_label}_unmeasured"
+    return f"h{height_label}_dt{_number_label(interval)}"
+
+
+def _number_label(value: float) -> str:
+    return f"{value:g}".replace("-", "m").replace(".", "p")

--- a/src/quantum_dynamics_lab/experiments.py
+++ b/src/quantum_dynamics_lab/experiments.py
@@ -46,36 +46,55 @@ def _run_single_wavefunction(config: ExperimentConfig) -> ExperimentResult:
     grid = make_grid(config.grid)
     potential = build_potential(config.potential, grid)
     psi = gaussian_packet(config.wave_packet, grid)
-    solver = SplitStepSolver(grid, potential, config.solver)
-    mask = transmission_mask(config.potential, grid)
-    masks = {"transmission": mask, "non_transmission": ~mask}
+    solver = SplitStepSolver(grid, potential, config.solver, config.boundary)
+    transmission = transmission_mask(config.potential, grid)
+    detector = _detector_mask(config, grid)
+    boundary = solver.absorber_mask < 0.999999
+    masks = {
+        "transmission": transmission,
+        "detector": detector,
+        "non_detector": ~detector,
+        "absorbing_boundary": boundary,
+    }
 
     frames: list[ComplexArray] = [psi.copy()]
     times: list[float] = [0.0]
     norm_series: list[float] = [norm(psi, grid)]
-    transmission_series: list[float] = [_probability_in_mask(psi, grid, mask)]
+    transmission_series: list[float] = [_probability_in_mask(psi, grid, transmission)]
+    unconditional_transmission_series: list[float] = [transmission_series[-1]]
     detected_series: list[float] = [0.0]
+    absorbed_series: list[float] = [0.0]
     survival_series: list[float] = [1.0]
     survival_weight = 1.0
     detected_probability = 0.0
+    absorbed_probability = 0.0
     next_measurement = _first_measurement_time(config)
 
     for step in range(1, solver.step_count + 1):
-        psi = solver.step(psi)
+        step_result = solver.step_with_diagnostics(psi)
+        psi = step_result.psi
         time = step * config.solver.dt
 
+        if step_result.absorbed_probability > 0:
+            absorbed_probability += survival_weight * step_result.absorbed_probability
+            survival_weight *= max(0.0, 1.0 - step_result.absorbed_probability)
+            if norm(psi, grid) > 0:
+                psi = normalize(psi, grid)
+
         if _measurement_due(config, time, next_measurement):
-            transmitted = _probability_in_mask(psi, grid, mask)
+            transmitted = _probability_in_mask(psi, grid, detector)
             detected_probability += survival_weight * transmitted
             survival_weight *= max(0.0, 1.0 - transmitted)
-            psi = np.where(mask, 0.0, psi)
+            psi = np.where(detector, 0.0, psi)
             if norm(psi, grid) > 0:
                 psi = normalize(psi, grid)
             next_measurement += config.measurement.interval or config.solver.tf
 
         norm_series.append(norm(psi, grid))
-        transmission_series.append(_probability_in_mask(psi, grid, mask))
+        transmission_series.append(_probability_in_mask(psi, grid, transmission))
+        unconditional_transmission_series.append(survival_weight * transmission_series[-1])
         detected_series.append(detected_probability)
+        absorbed_series.append(absorbed_probability)
         survival_series.append(survival_weight)
         if step % solver.frame_stride == 0 or step == solver.step_count:
             frames.append(psi.copy())
@@ -88,7 +107,11 @@ def _run_single_wavefunction(config: ExperimentConfig) -> ExperimentResult:
         * config.solver.dt,
         "norm": np.asarray(norm_series, dtype=np.float64),
         "transmission_probability": np.asarray(transmission_series, dtype=np.float64),
+        "unconditional_transmission_probability": np.asarray(
+            unconditional_transmission_series, dtype=np.float64
+        ),
         "detected_probability": np.asarray(detected_series, dtype=np.float64),
+        "absorbed_probability": np.asarray(absorbed_series, dtype=np.float64),
         "survival_weight": np.asarray(survival_series, dtype=np.float64),
     }
     metrics = _base_metrics(config, grid, arrays)
@@ -96,8 +119,13 @@ def _run_single_wavefunction(config: ExperimentConfig) -> ExperimentResult:
         {
             "final_norm": float(norm_series[-1]),
             "final_transmission_probability": float(transmission_series[-1]),
+            "final_unconditional_transmission_probability": float(
+                unconditional_transmission_series[-1]
+            ),
             "final_detected_probability": float(detected_series[-1]),
+            "final_absorbed_probability": float(absorbed_series[-1]),
             "final_survival_weight": float(survival_series[-1]),
+            "detector_x": float(_detector_x(config)),
         }
     )
     return ExperimentResult(config, grid, potential, masks, arrays, metrics)
@@ -107,7 +135,7 @@ def _run_double_slit(config: ExperimentConfig) -> ExperimentResult:
     grid = make_grid(config.grid)
     potential = build_potential(config.potential, grid)
     psi = gaussian_packet(config.wave_packet, grid)
-    solver = SplitStepSolver(grid, potential, config.solver)
+    solver = SplitStepSolver(grid, potential, config.solver, config.boundary)
     transmission = transmission_mask(config.potential, grid)
     upper_slit = upper_slit_mask(config.potential, grid)
     lower_slit = lower_slit_mask(config.potential, grid)
@@ -215,6 +243,17 @@ def _which_path_time(config: ExperimentConfig) -> float:
 
 def _probability_in_mask(psi: ComplexArray, grid: Grid, mask: BoolArray) -> float:
     return integrate_probability(np.where(mask, np.abs(psi) ** 2, 0.0), grid)
+
+
+def _detector_mask(config: ExperimentConfig, grid: Grid) -> BoolArray:
+    return grid.X >= _detector_x(config)
+
+
+def _detector_x(config: ExperimentConfig) -> float:
+    if config.measurement.detector_x is not None:
+        return config.measurement.detector_x
+    barrier_right_edge = config.potential.barrier_x + config.potential.barrier_width / 2.0
+    return barrier_right_edge + config.measurement.detector_buffer
 
 
 def _screen_profile(probability: FloatArray, transmission: BoolArray) -> FloatArray:

--- a/src/quantum_dynamics_lab/render.py
+++ b/src/quantum_dynamics_lab/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any
+import csv
 import shutil
 
 import matplotlib
@@ -23,6 +24,7 @@ def render_run(run_path: str | Path, out_dir: str | Path | None = None) -> dict[
     outputs: dict[str, Path] = {}
     outputs["potential"] = _plot_potential(data, out_dir / "potential.png")
     outputs["summary"] = _plot_summary(data, out_dir / "summary.png")
+    outputs["report"] = _write_run_report(data, outputs, out_dir / "report.md")
     if data["metadata"]["config"]["output"].get("render_video", True):
         video = _render_video(data, out_dir / "probability.mp4")
         if video is not None:
@@ -35,32 +37,48 @@ def render_comparison(run_dirs: list[Path], out_dir: str | Path) -> Path:
 
     out_dir = Path(out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
-    rows = []
+    rows: list[dict[str, float | str | None]] = []
     for run_dir in run_dirs:
         run = load_run(run_dir / "run.npz")
         metadata = run["metadata"]
         config = metadata["config"]
-        interval = config["measurement"].get("interval")
-        detected = _last(run.get("detected_probability"))
-        transmitted = _last(run.get("transmission_probability"))
-        rows.append((config["name"], interval or 0.0, detected, transmitted))
-    rows.sort(key=lambda row: row[1])
+        rows.append(_comparison_row(config, run))
+    rows.sort(key=lambda row: (float(row["barrier_height"]), float(row["interval_sort"])))
+    _write_comparison_csv(rows, out_dir / "comparison.csv")
 
-    fig, ax = plt.subplots(figsize=(7, 4))
-    labels = [row[0] for row in rows]
-    detected = [row[2] for row in rows]
-    transmitted = [row[3] for row in rows]
-    x = np.arange(len(rows))
-    ax.bar(x - 0.18, detected, width=0.36, label="Detected")
-    ax.bar(x + 0.18, transmitted, width=0.36, label="Conditional transmitted")
-    ax.set_xticks(x, labels, rotation=20, ha="right")
-    ax.set_ylabel("Probability")
-    ax.set_title("Zeno measurement sweep")
-    ax.legend()
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.5), sharex=False)
+    heights = sorted({float(row["barrier_height"]) for row in rows})
+    for height in heights:
+        group = [row for row in rows if float(row["barrier_height"]) == height]
+        group.sort(key=lambda row: float(row["interval_sort"]))
+        x = [float(row["interval_sort"]) for row in group]
+        label = f"V0={height:g}"
+        axes[0].plot(
+            x,
+            [float(row["unconditional_transmission_probability"]) for row in group],
+            marker="o",
+            label=label,
+        )
+        axes[1].plot(
+            x,
+            [float(row["survival_weight"]) for row in group],
+            marker="o",
+            label=label,
+        )
+    axes[0].set_title("No-click branch transmission")
+    axes[0].set_xlabel("measurement interval (0 = unmeasured)")
+    axes[0].set_ylabel("probability")
+    axes[1].set_title("No-click survival weight")
+    axes[1].set_xlabel("measurement interval (0 = unmeasured)")
+    for ax in axes:
+        ax.grid(True, alpha=0.3)
+        ax.legend()
     fig.tight_layout()
     path = out_dir / "comparison.png"
     fig.savefig(path, dpi=160)
     plt.close(fig)
+    heatmap_path = _plot_transmission_heatmap(rows, out_dir / "zeno_transmission_heatmap.png")
+    _write_comparison_report(rows, path, heatmap_path, out_dir / "report.md")
     return path
 
 
@@ -134,8 +152,16 @@ def _plot_summary(data: dict[str, Any], path: Path) -> Path:
                 data["transmission_probability"],
                 label="conditional transmitted",
             )
+        if "unconditional_transmission_probability" in data:
+            axes[1, 1].plot(
+                metric_times,
+                data["unconditional_transmission_probability"],
+                label="unconditional transmitted",
+            )
         if "detected_probability" in data:
             axes[1, 1].plot(metric_times, data["detected_probability"], label="detected")
+        if "absorbed_probability" in data:
+            axes[1, 1].plot(metric_times, data["absorbed_probability"], label="absorbed")
         if "survival_weight" in data:
             axes[1, 1].plot(metric_times, data["survival_weight"], label="survival")
         axes[1, 1].set_title("Measurement probabilities")
@@ -200,3 +226,148 @@ def _last(value: Any) -> float:
     if value is None:
         return 0.0
     return float(np.asarray(value)[-1])
+
+
+def _comparison_row(config: dict[str, Any], run: dict[str, Any]) -> dict[str, float | str | None]:
+    interval = config["measurement"].get("interval")
+    interval_sort = 0.0 if interval is None else float(interval)
+    return {
+        "name": config["name"],
+        "barrier_height": float(config["potential"]["height"]),
+        "interval": None if interval is None else float(interval),
+        "interval_sort": interval_sort,
+        "detector_x": _detector_x_from_config(config),
+        "detected_probability": _last(run.get("detected_probability")),
+        "absorbed_probability": _last(run.get("absorbed_probability")),
+        "survival_weight": _last(run.get("survival_weight")),
+        "conditional_transmission_probability": _last(run.get("transmission_probability")),
+        "unconditional_transmission_probability": _last(
+            run.get("unconditional_transmission_probability")
+        ),
+    }
+
+
+def _write_comparison_csv(rows: list[dict[str, float | str | None]], path: Path) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(rows[0].keys()))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _detector_x_from_config(config: dict[str, Any]) -> float:
+    measurement = config["measurement"]
+    if measurement.get("detector_x") is not None:
+        return float(measurement["detector_x"])
+    potential = config["potential"]
+    return (
+        float(potential["barrier_x"])
+        + float(potential["barrier_width"]) / 2.0
+        + float(measurement.get("detector_buffer", 0.0))
+    )
+
+
+def _plot_transmission_heatmap(rows: list[dict[str, float | str | None]], path: Path) -> Path:
+    heights = sorted({float(row["barrier_height"]) for row in rows})
+    intervals = sorted({float(row["interval_sort"]) for row in rows})
+    matrix = np.full((len(heights), len(intervals)), np.nan)
+    for row in rows:
+        h_index = heights.index(float(row["barrier_height"]))
+        i_index = intervals.index(float(row["interval_sort"]))
+        matrix[h_index, i_index] = float(row["unconditional_transmission_probability"])
+    fig, ax = plt.subplots(figsize=(7, 4.5))
+    image = ax.imshow(matrix, origin="lower", cmap="viridis", aspect="auto")
+    ax.set_xticks(np.arange(len(intervals)), [f"{value:g}" for value in intervals])
+    ax.set_yticks(np.arange(len(heights)), [f"{value:g}" for value in heights])
+    ax.set_xlabel("measurement interval (0 = unmeasured)")
+    ax.set_ylabel("barrier height")
+    ax.set_title("No-click transmission heatmap")
+    fig.colorbar(image, ax=ax, label="probability")
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+    return path
+
+
+def _write_run_report(data: dict[str, Any], outputs: dict[str, Path], path: Path) -> Path:
+    config = data["metadata"]["config"]
+    lines = [
+        f"# {config['name']} report",
+        "",
+        f"- Experiment: `{config['experiment']}`",
+        f"- Grid: {config['grid']['n']} x {config['grid']['n']}, L={config['grid']['length']}",
+        f"- Boundary: `{config['boundary']['kind']}`",
+        f"- Measurement: `{config['measurement']['kind']}`",
+        "",
+        "## Figures",
+        "",
+        f"![Summary]({outputs['summary'].name})",
+        "",
+        f"![Potential]({outputs['potential'].name})",
+        "",
+    ]
+    if "detected_probability" in data:
+        lines.extend(
+            [
+                "## Final probabilities",
+                "",
+                "| Quantity | Value |",
+                "| --- | ---: |",
+                f"| Detector clicks | {_last(data.get('detected_probability')):.6f} |",
+                f"| Absorbed at boundary | {_last(data.get('absorbed_probability')):.6f} |",
+                f"| No-click survival | {_last(data.get('survival_weight')):.6f} |",
+                f"| Conditional transmission | {_last(data.get('transmission_probability')):.6f} |",
+                f"| Unconditional transmission | {_last(data.get('unconditional_transmission_probability')):.6f} |",
+                "",
+            ]
+        )
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _write_comparison_report(
+    rows: list[dict[str, float | str | None]], comparison: Path, heatmap: Path, path: Path
+) -> Path:
+    lines = [
+        "# Zeno barrier sweep report",
+        "",
+        "This report compares no-click branch transmission, detector-click probability, boundary absorption, and no-click survival across barrier heights and repeated-measurement intervals.",
+        "",
+        "The measurement model treats each detector check as a no-click projection: probability in the detector region is accumulated as detector-click probability, removed from the conditional wavefunction, and the remaining branch is renormalized while survival weight records the unconditional no-click probability.",
+        "",
+        "Absorbing boundaries damp wavefunction amplitude near the edges after each split-step update; absorbed probability is tracked separately from detector clicks.",
+        "",
+        "The primary Zeno signal in this model is the unconditional transmission remaining in the no-click branch. Cumulative detector clicks are still reported, but they also reflect how many detector checks had a chance to remove already-transmitted amplitude.",
+        "",
+        "## Figures",
+        "",
+        f"![Comparison]({comparison.name})",
+        "",
+        f"![No-click transmission heatmap]({heatmap.name})",
+        "",
+        "## Sweep table",
+        "",
+        "| Run | V0 | interval | detector | absorbed | survival | unconditional transmission |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for row in rows:
+        interval = "unmeasured" if row["interval"] is None else f"{float(row['interval']):.6g}"
+        lines.append(
+            f"| {row['name']} | {float(row['barrier_height']):.6g} | {interval} | "
+            f"{float(row['detected_probability']):.6f} | "
+            f"{float(row['absorbed_probability']):.6f} | "
+            f"{float(row['survival_weight']):.6f} | "
+            f"{float(row['unconditional_transmission_probability']):.6f} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Reading the sweep",
+            "",
+            "- Smaller measurement intervals correspond to more frequent detector checks.",
+            "- A Zeno-like suppression signal appears when no-click branch transmission falls as detector checks become more frequent.",
+            "- Absorbed probability is a boundary artifact control, not a detector event; large absorption indicates the simulation box or final time should be revisited.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path

--- a/src/quantum_dynamics_lab/solver.py
+++ b/src/quantum_dynamics_lab/solver.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
-from .config import SolverConfig
-from .grid import Grid
+from .config import BoundaryConfig, SolverConfig
+from .grid import Grid, norm
 
 
 ComplexArray = NDArray[np.complex128]
@@ -14,10 +14,17 @@ FloatArray = NDArray[np.float64]
 
 
 @dataclass(frozen=True)
+class StepResult:
+    psi: ComplexArray
+    absorbed_probability: float
+
+
+@dataclass(frozen=True)
 class SplitStepSolver:
     grid: Grid
     potential: FloatArray
     config: SolverConfig
+    boundary: BoundaryConfig = BoundaryConfig()
 
     def __post_init__(self) -> None:
         if self.config.dt <= 0:
@@ -28,6 +35,12 @@ class SplitStepSolver:
             raise ValueError("solver.mass must be positive")
         if self.config.hbar <= 0:
             raise ValueError("solver.hbar must be positive")
+        if self.boundary.width < 0:
+            raise ValueError("boundary.width must be non-negative")
+        if self.boundary.strength < 0:
+            raise ValueError("boundary.strength must be non-negative")
+        if self.boundary.power <= 0:
+            raise ValueError("boundary.power must be positive")
 
     @property
     def step_count(self) -> int:
@@ -38,6 +51,9 @@ class SplitStepSolver:
         return max(1, int(round(self.config.frame_interval / self.config.dt)))
 
     def step(self, psi: ComplexArray) -> ComplexArray:
+        return self.step_with_diagnostics(psi).psi
+
+    def step_with_diagnostics(self, psi: ComplexArray) -> StepResult:
         dt = self.config.dt
         hbar = self.config.hbar
         mass = self.config.mass
@@ -45,4 +61,27 @@ class SplitStepSolver:
         kinetic = np.exp(-1j * hbar * self.grid.k2 * dt / (2.0 * mass))
         psi = position_half * psi
         psi = np.fft.ifft2(np.fft.fft2(psi) * kinetic)
-        return (position_half * psi).astype(np.complex128)
+        psi = (position_half * psi).astype(np.complex128)
+        before_absorber = norm(psi, self.grid)
+        psi = self.absorber_mask * psi
+        absorbed = max(0.0, before_absorber - norm(psi, self.grid))
+        return StepResult(psi=psi.astype(np.complex128), absorbed_probability=absorbed)
+
+    @property
+    def absorber_mask(self) -> FloatArray:
+        if self.boundary.kind.lower() != "absorbing":
+            return np.ones((self.grid.n, self.grid.n), dtype=np.float64)
+        if self.boundary.width <= 0 or self.boundary.strength <= 0:
+            return np.ones((self.grid.n, self.grid.n), dtype=np.float64)
+        half_length = self.grid.length / 2.0
+        distance_to_edge = np.minimum.reduce(
+            [
+                self.grid.X + half_length,
+                half_length - self.grid.X,
+                self.grid.Y + half_length,
+                half_length - self.grid.Y,
+            ]
+        )
+        scaled = np.clip((self.boundary.width - distance_to_edge) / self.boundary.width, 0.0, 1.0)
+        damping = self.boundary.strength * np.power(scaled, self.boundary.power)
+        return np.exp(-damping * self.config.dt).astype(np.float64)

--- a/tests/test_solver_experiments_cli.py
+++ b/tests/test_solver_experiments_cli.py
@@ -4,12 +4,14 @@ import numpy as np
 
 from quantum_dynamics_lab.cli import main
 from quantum_dynamics_lab.config import (
+    BoundaryConfig,
     ExperimentConfig,
     GridConfig,
     MeasurementConfig,
     PotentialConfig,
     SolverConfig,
     WavePacketConfig,
+    load_sweep_config,
 )
 from quantum_dynamics_lab.experiments import run_experiment
 from quantum_dynamics_lab.grid import make_grid, norm, normalize
@@ -79,6 +81,24 @@ def test_barrier_zeno_fast_measurement_reduces_detection() -> None:
         fast.metrics["final_detected_probability"]
         < slow.metrics["final_detected_probability"]
     )
+    assert "final_unconditional_transmission_probability" in fast.metrics
+
+
+def test_absorbing_boundary_tracks_probability_loss() -> None:
+    result = run_experiment(
+        ExperimentConfig(
+            name="absorber",
+            experiment="free_packet",
+            grid=GridConfig(n=32, length=8.0),
+            wave_packet=WavePacketConfig(center=(2.6, 0.0), sigma=0.45, momentum=(5.0, 0.0)),
+            potential=PotentialConfig(kind="free"),
+            solver=SolverConfig(dt=0.002, tf=0.25, frame_interval=0.05),
+            boundary=BoundaryConfig(kind="absorbing", width=1.2, strength=5.0),
+        )
+    )
+
+    assert result.metrics["final_absorbed_probability"] > 0.0
+    assert result.metrics["final_survival_weight"] < 1.0
 
 
 def test_double_slit_which_path_reduces_interference_contrast() -> None:
@@ -125,3 +145,75 @@ def test_cli_run_and_render_smoke(tmp_path) -> None:
     assert main(["render", str(out / "run.npz"), "--out", str(out / "report")]) == 0
     assert (out / "report" / "summary.png").exists()
     assert (out / "report" / "potential.png").exists()
+    assert (out / "report" / "report.md").exists()
+
+
+def test_research_sweep_scan_expands_variants() -> None:
+    sweep = load_sweep_config("examples/zeno_research_sweep.toml")
+
+    assert len(sweep.variants) == 12
+    assert sweep.variants[0].potential_height == 25.0
+    assert sweep.variants[0].measurement_interval is None
+
+
+def test_compare_generates_polished_report(tmp_path) -> None:
+    base = tmp_path / "base.toml"
+    base.write_text(
+        """
+name = "small_zeno"
+experiment = "barrier_zeno"
+
+[grid]
+n = 24
+length = 8.0
+
+[wave_packet]
+center = [-2.0, 0.0]
+sigma = 0.45
+momentum = [4.0, 0.0]
+
+[potential]
+kind = "barrier"
+height = 30.0
+barrier_x = 0.0
+barrier_width = 0.25
+
+[solver]
+dt = 0.004
+tf = 0.12
+frame_interval = 0.04
+
+[boundary]
+kind = "absorbing"
+width = 1.0
+strength = 4.0
+
+[measurement]
+kind = "zeno"
+interval = 0.08
+detector_buffer = 0.25
+
+[output]
+render_video = false
+""",
+        encoding="utf-8",
+    )
+    sweep = tmp_path / "sweep.toml"
+    sweep.write_text(
+        """
+name = "small_sweep"
+base_config = "base.toml"
+
+[scan]
+potential_heights = [30.0]
+measurement_intervals = [0.0, 0.08]
+""",
+        encoding="utf-8",
+    )
+    out = tmp_path / "comparison"
+
+    assert main(["compare", str(sweep), "--out", str(out)]) == 0
+    assert (out / "comparison.csv").exists()
+    assert (out / "comparison.png").exists()
+    assert (out / "zeno_transmission_heatmap.png").exists()
+    assert (out / "report.md").exists()


### PR DESCRIPTION
## Summary
- add optional absorbing boundaries and track absorbed probability separately from detector clicks
- make Zeno detector placement explicit with derived detector masks and no-click branch accounting
- add generated parameter scans over barrier height and measurement interval
- generate polished run/sweep reports with Markdown, CSV, comparison plots, and no-click transmission heatmaps
- add tests for absorbing boundary loss, scan expansion, report generation, and new Zeno metrics

## Tracking
Closes #13

## Validation
- `uv run pytest`
- `uv run python -m compileall -q src tests`
- `uv run quantum-lab compare examples/zeno_research_sweep.toml --out reports/zeno_research_sweep`

## Generated local report
- `reports/zeno_research_sweep/report.md`
- `reports/zeno_research_sweep/comparison.csv`
- `reports/zeno_research_sweep/comparison.png`
- `reports/zeno_research_sweep/zeno_transmission_heatmap.png`