### PR TITLE
Add reports explorer narrative and optional backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ uv run quantum-lab run examples/free_packet.toml --out runs/free_packet
 uv run quantum-lab run examples/barrier_zeno.toml --out runs/barrier_zeno
 uv run quantum-lab compare examples/zeno_sweep.toml --out reports/zeno_sweep
 uv run quantum-lab compare examples/zeno_research_sweep.toml --out reports/zeno_research_sweep
+uv run quantum-lab run examples/double_slit.toml --out runs/double_slit
+uv run quantum-lab narrative --zeno reports/zeno_research_sweep --double-slit runs/double_slit/run.npz --out reports/research_narrative
 uv run quantum-lab render runs/free_packet/run.npz --out reports/free_packet
 ```
 
@@ -43,6 +45,12 @@ conditional wavefunction, and the no-click branch is renormalized while
 survival weight tracks the unconditional probability. Generated comparison
 reports include `comparison.csv`, `comparison.png`, `zeno_transmission_heatmap.png`,
 and `report.md`.
+
+Optional FFT backends can be selected in `[solver]` with `backend = "numpy"`,
+`"pyfftw"`, `"cupy"`, or `"auto"`. The default `auto` uses pyFFTW when it is
+installed and otherwise falls back to NumPy; CuPy and pyFFTW remain optional
+dependencies. Install them with `uv sync --extra fftw` or
+`uv sync --extra cuda12` when the local machine supports those runtimes.
 
 ---
 

--- a/examples/double_slit.toml
+++ b/examples/double_slit.toml
@@ -28,4 +28,4 @@ kind = "which_path"
 
 [output]
 fps = 20
-render_video = true
+render_video = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,10 @@ dependencies = [
     "numpy>=2.0",
 ]
 
+[project.optional-dependencies]
+fftw = ["pyfftw>=0.15"]
+cuda12 = ["cupy-cuda12x>=13"]
+
 [project.scripts]
 quantum-lab = "quantum_dynamics_lab.cli:main"
 

--- a/src/quantum_dynamics_lab/artifacts.py
+++ b/src/quantum_dynamics_lab/artifacts.py
@@ -48,7 +48,7 @@ def write_metrics(path: str | Path, metrics: dict[str, Any]) -> None:
 
 def _metadata(result: ExperimentResult) -> dict[str, Any]:
     return {
-        "backend": "numpy",
+        "backend": str(result.metrics.get("backend", "numpy")),
         "config": result.config.to_dict(),
         "created_at": datetime.now(UTC).isoformat(),
         "git_commit": _git_commit(),

--- a/src/quantum_dynamics_lab/backends.py
+++ b/src/quantum_dynamics_lab/backends.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+ComplexArray = NDArray[np.complex128]
+
+
+class FFTBackend(Protocol):
+    name: str
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        ...
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        ...
+
+
+@dataclass(frozen=True)
+class NumPyBackend:
+    name: str = "numpy"
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        return np.fft.fft2(values)
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        return np.fft.ifft2(values)
+
+
+@dataclass(frozen=True)
+class PyFFTWBackend:
+    name: str = "pyfftw"
+
+    def __post_init__(self) -> None:
+        try:
+            import pyfftw.interfaces.numpy_fft as numpy_fft  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError("pyFFTW backend requested but pyfftw is not installed") from exc
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        import pyfftw.interfaces.numpy_fft as fftw_fft
+
+        return fftw_fft.fft2(values)
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        import pyfftw.interfaces.numpy_fft as fftw_fft
+
+        return fftw_fft.ifft2(values)
+
+
+@dataclass(frozen=True)
+class CuPyBackend:
+    name: str = "cupy"
+
+    def __post_init__(self) -> None:
+        try:
+            import cupy as cp  # noqa: F401
+        except ImportError as exc:
+            raise RuntimeError("CuPy backend requested but cupy is not installed") from exc
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        import cupy as cp
+
+        return cp.asnumpy(cp.fft.fft2(cp.asarray(values)))
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        import cupy as cp
+
+        return cp.asnumpy(cp.fft.ifft2(cp.asarray(values)))
+
+
+def create_backend(name: str) -> FFTBackend:
+    normalized = name.lower()
+    if normalized == "numpy":
+        return NumPyBackend()
+    if normalized == "pyfftw":
+        return PyFFTWBackend()
+    if normalized == "cupy":
+        return CuPyBackend()
+    if normalized == "auto":
+        try:
+            return PyFFTWBackend()
+        except RuntimeError:
+            return NumPyBackend()
+    raise ValueError(f"unsupported FFT backend: {name}")

--- a/src/quantum_dynamics_lab/cli.py
+++ b/src/quantum_dynamics_lab/cli.py
@@ -6,7 +6,7 @@ import argparse
 from .artifacts import save_run, write_metrics
 from .config import apply_sweep_variant, load_experiment_config, load_sweep_config
 from .experiments import run_experiment
-from .render import render_comparison, render_run
+from .render import render_comparison, render_research_narrative, render_run
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -26,6 +26,13 @@ def main(argv: list[str] | None = None) -> int:
     compare_parser.add_argument("config", type=Path)
     compare_parser.add_argument("--out", type=Path, required=True)
     compare_parser.add_argument("--skip-render", action="store_true")
+
+    narrative_parser = subparsers.add_parser(
+        "narrative", help="Build a research narrative from generated artifacts"
+    )
+    narrative_parser.add_argument("--zeno", type=Path, required=True)
+    narrative_parser.add_argument("--double-slit", type=Path, required=True)
+    narrative_parser.add_argument("--out", type=Path, required=True)
 
     args = parser.parse_args(argv)
     if args.command == "run":
@@ -57,6 +64,10 @@ def main(argv: list[str] | None = None) -> int:
         if not args.skip_render:
             render_comparison(run_dirs, args.out)
         write_metrics(args.out / "metrics.json", summary)
+        print(args.out)
+        return 0
+    if args.command == "narrative":
+        render_research_narrative(args.zeno, args.double_slit, args.out)
         print(args.out)
         return 0
     return 2

--- a/src/quantum_dynamics_lab/config.py
+++ b/src/quantum_dynamics_lab/config.py
@@ -37,6 +37,7 @@ class SolverConfig:
     frame_interval: float = 0.02
     hbar: float = 1.0
     mass: float = 1.0
+    backend: str = "auto"
 
 
 @dataclass(frozen=True)
@@ -149,6 +150,7 @@ def load_experiment_config(path: str | Path) -> ExperimentConfig:
         ),
         hbar=float(solver_data.get("hbar", SolverConfig.hbar)),
         mass=float(solver_data.get("mass", SolverConfig.mass)),
+        backend=str(solver_data.get("backend", SolverConfig.backend)),
     )
     boundary = BoundaryConfig(
         kind=str(boundary_data.get("kind", BoundaryConfig.kind)),

--- a/src/quantum_dynamics_lab/experiments.py
+++ b/src/quantum_dynamics_lab/experiments.py
@@ -117,6 +117,7 @@ def _run_single_wavefunction(config: ExperimentConfig) -> ExperimentResult:
     metrics = _base_metrics(config, grid, arrays)
     metrics.update(
         {
+            "backend": solver.backend_name,
             "final_norm": float(norm_series[-1]),
             "final_transmission_probability": float(transmission_series[-1]),
             "final_unconditional_transmission_probability": float(
@@ -202,6 +203,7 @@ def _run_double_slit(config: ExperimentConfig) -> ExperimentResult:
     metrics = _base_metrics(config, grid, arrays)
     metrics.update(
         {
+            "backend": solver.backend_name,
             "final_norm": float(norm_series[-1]),
             "final_which_path_norm": float(which_path_norm_series[-1]),
             "coherent_interference_contrast": float(contrast_coherent),

--- a/src/quantum_dynamics_lab/render.py
+++ b/src/quantum_dynamics_lab/render.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 import csv
+import html
+import json
 import shutil
 
 import matplotlib
@@ -12,6 +14,52 @@ matplotlib.use("Agg")
 import matplotlib.pyplot as plt
 from matplotlib.animation import FFMpegWriter
 import numpy as np
+
+
+def render_research_narrative(
+    zeno_dir: str | Path, double_slit_run: str | Path, out_dir: str | Path
+) -> dict[str, Path]:
+    from .artifacts import load_run
+
+    zeno_dir = Path(zeno_dir)
+    double_slit_run = Path(double_slit_run)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    rows = _read_comparison_csv(zeno_dir / "comparison.csv")
+    double_data = load_run(double_slit_run)
+    double_metrics_path = double_slit_run.parent / "metrics.json"
+    double_metrics = (
+        json.loads(double_metrics_path.read_text(encoding="utf-8"))
+        if double_metrics_path.exists()
+        else {}
+    )
+    zeno_comparison = _copy_if_exists(zeno_dir / "comparison.png", out_dir / "zeno_comparison.png")
+    zeno_heatmap = _copy_if_exists(
+        zeno_dir / "zeno_transmission_heatmap.png",
+        out_dir / "zeno_transmission_heatmap.png",
+    )
+    double_summary = _copy_if_exists(
+        double_slit_run.parent / "summary.png", out_dir / "double_slit_summary.png"
+    )
+
+    narrative_path = _write_full_research_narrative(
+        rows=rows,
+        zeno_comparison=zeno_comparison,
+        zeno_heatmap=zeno_heatmap,
+        double_summary=double_summary,
+        double_config=double_data["metadata"]["config"],
+        double_metrics=double_metrics,
+        path=out_dir / "research_narrative.md",
+    )
+    html_path = _write_html_from_markdown(narrative_path, out_dir / "research_narrative.html")
+    return {"narrative": narrative_path, "html": html_path}
+
+
+def _copy_if_exists(source: Path, destination: Path) -> Path:
+    if source.exists():
+        shutil.copy2(source, destination)
+    return destination
 
 
 def render_run(run_path: str | Path, out_dir: str | Path | None = None) -> dict[str, Path]:
@@ -25,6 +73,9 @@ def render_run(run_path: str | Path, out_dir: str | Path | None = None) -> dict[
     outputs["potential"] = _plot_potential(data, out_dir / "potential.png")
     outputs["summary"] = _plot_summary(data, out_dir / "summary.png")
     outputs["report"] = _write_run_report(data, outputs, out_dir / "report.md")
+    outputs["html_report"] = _write_html_from_markdown(
+        outputs["report"], out_dir / "report.html"
+    )
     if data["metadata"]["config"]["output"].get("render_video", True):
         video = _render_video(data, out_dir / "probability.mp4")
         if video is not None:
@@ -78,7 +129,11 @@ def render_comparison(run_dirs: list[Path], out_dir: str | Path) -> Path:
     fig.savefig(path, dpi=160)
     plt.close(fig)
     heatmap_path = _plot_transmission_heatmap(rows, out_dir / "zeno_transmission_heatmap.png")
-    _write_comparison_report(rows, path, heatmap_path, out_dir / "report.md")
+    report_path = _write_comparison_report(rows, path, heatmap_path, out_dir / "report.md")
+    _write_html_from_markdown(report_path, out_dir / "report.html")
+    _write_explorer(rows, out_dir / "explorer.html")
+    _write_research_narrative(rows, path, heatmap_path, out_dir / "research_narrative.md")
+    _write_html_from_markdown(out_dir / "research_narrative.md", out_dir / "research_narrative.html")
     return path
 
 
@@ -254,6 +309,22 @@ def _write_comparison_csv(rows: list[dict[str, float | str | None]], path: Path)
         writer.writerows(rows)
 
 
+def _read_comparison_csv(path: Path) -> list[dict[str, float | str | None]]:
+    rows: list[dict[str, float | str | None]] = []
+    with path.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            parsed: dict[str, float | str | None] = {"name": row["name"]}
+            for key, value in row.items():
+                if key == "name":
+                    continue
+                if value == "":
+                    parsed[key] = None
+                else:
+                    parsed[key] = float(value)
+            rows.append(parsed)
+    return rows
+
+
 def _detector_x_from_config(config: dict[str, Any]) -> float:
     measurement = config["measurement"]
     if measurement.get("detector_x") is not None:
@@ -369,5 +440,259 @@ def _write_comparison_report(
             "",
         ]
     )
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _write_html_from_markdown(markdown_path: Path, html_path: Path) -> Path:
+    markdown = markdown_path.read_text(encoding="utf-8")
+    body = _simple_markdown_to_html(markdown)
+    html_text = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(markdown_path.stem.replace('_', ' ').title())}</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; max-width: 1080px; margin: 2rem auto; padding: 0 1rem; color: #17202a; }}
+    h1, h2 {{ line-height: 1.2; }}
+    img {{ max-width: 100%; height: auto; border: 1px solid #d6dbe0; }}
+    table {{ border-collapse: collapse; width: 100%; margin: 1rem 0; font-size: 0.92rem; }}
+    th, td {{ border: 1px solid #d6dbe0; padding: 0.45rem 0.6rem; text-align: right; }}
+    th:first-child, td:first-child {{ text-align: left; }}
+    code {{ background: #f1f3f5; padding: 0.1rem 0.25rem; border-radius: 4px; }}
+  </style>
+</head>
+<body>
+{body}
+</body>
+</html>
+"""
+    html_path.write_text(html_text, encoding="utf-8")
+    return html_path
+
+
+def _simple_markdown_to_html(markdown: str) -> str:
+    lines = markdown.splitlines()
+    output: list[str] = []
+    table: list[str] = []
+    in_list = False
+    for line in lines:
+        if table and not line.startswith("|"):
+            output.append(_table_to_html(table))
+            table = []
+        if in_list and not line.startswith("- "):
+            output.append("</ul>")
+            in_list = False
+        if line.startswith("|"):
+            table.append(line)
+        elif line.startswith("# "):
+            output.append(f"<h1>{html.escape(line[2:])}</h1>")
+        elif line.startswith("## "):
+            output.append(f"<h2>{html.escape(line[3:])}</h2>")
+        elif line.startswith("![") and "](" in line and line.endswith(")"):
+            alt, src = line[2:-1].split("](", 1)
+            output.append(f'<p><img src="{html.escape(src)}" alt="{html.escape(alt)}"></p>')
+        elif line.startswith("- "):
+            if not in_list:
+                output.append("<ul>")
+                in_list = True
+            output.append(f"<li>{_inline_markdown(line[2:])}</li>")
+        elif not line.strip():
+            output.append("")
+        else:
+            output.append(f"<p>{_inline_markdown(line)}</p>")
+    if table:
+        output.append(_table_to_html(table))
+    if in_list:
+        output.append("</ul>")
+    return "\n".join(output)
+
+
+def _table_to_html(lines: list[str]) -> str:
+    rows = []
+    for index, line in enumerate(lines):
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if index == 1 and all(set(cell) <= {"-", ":"} for cell in cells):
+            continue
+        tag = "th" if index == 0 else "td"
+        rows.append("<tr>" + "".join(f"<{tag}>{_inline_markdown(cell)}</{tag}>" for cell in cells) + "</tr>")
+    return "<table>\n" + "\n".join(rows) + "\n</table>"
+
+
+def _inline_markdown(text: str) -> str:
+    escaped = html.escape(text)
+    parts = escaped.split("`")
+    for index in range(1, len(parts), 2):
+        parts[index] = f"<code>{parts[index]}</code>"
+    return "".join(parts)
+
+
+def _write_explorer(rows: list[dict[str, float | str | None]], path: Path) -> Path:
+    data = json.dumps(rows)
+    heights = sorted({float(row["barrier_height"]) for row in rows})
+    intervals = sorted({float(row["interval_sort"]) for row in rows})
+    html_text = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Zeno Parameter Explorer</title>
+  <style>
+    body {{ font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 2rem auto; max-width: 980px; padding: 0 1rem; color: #17202a; }}
+    .controls {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem; margin: 1.5rem 0; }}
+    label {{ display: grid; gap: 0.35rem; font-weight: 600; }}
+    select {{ font: inherit; padding: 0.4rem; }}
+    .metrics {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }}
+    .metric {{ border: 1px solid #d6dbe0; padding: 0.8rem; }}
+    .metric span {{ display: block; font-size: 0.85rem; color: #52616f; }}
+    .metric strong {{ font-size: 1.35rem; }}
+    table {{ width: 100%; border-collapse: collapse; margin-top: 1.5rem; font-size: 0.9rem; }}
+    th, td {{ border: 1px solid #d6dbe0; padding: 0.45rem; text-align: right; }}
+    th:first-child, td:first-child {{ text-align: left; }}
+  </style>
+</head>
+<body>
+  <h1>Zeno Parameter Explorer</h1>
+  <p>Inspect how barrier height and measurement interval change no-click transmission, detector clicks, survival weight, and boundary absorption.</p>
+  <div class="controls">
+    <label>Barrier height<select id="height"></select></label>
+    <label>Measurement interval<select id="interval"></select></label>
+  </div>
+  <div class="metrics" id="metrics"></div>
+  <table id="table"></table>
+  <script>
+    const rows = {data};
+    const heights = {json.dumps(heights)};
+    const intervals = {json.dumps(intervals)};
+    const heightSelect = document.querySelector("#height");
+    const intervalSelect = document.querySelector("#interval");
+    const metrics = document.querySelector("#metrics");
+    const table = document.querySelector("#table");
+    for (const value of heights) heightSelect.add(new Option(value, value));
+    for (const value of intervals) intervalSelect.add(new Option(value === 0 ? "unmeasured" : value, value));
+    function selectedRow() {{
+      return rows.find(row => Number(row.barrier_height) === Number(heightSelect.value) && Number(row.interval_sort) === Number(intervalSelect.value));
+    }}
+    function fmt(value) {{ return Number(value).toFixed(6); }}
+    function render() {{
+      const row = selectedRow();
+      metrics.innerHTML = "";
+      for (const [label, key] of [
+        ["No-click transmission", "unconditional_transmission_probability"],
+        ["Detector clicks", "detected_probability"],
+        ["No-click survival", "survival_weight"],
+        ["Boundary absorption", "absorbed_probability"],
+      ]) {{
+        const div = document.createElement("div");
+        div.className = "metric";
+        div.innerHTML = `<span>${{label}}</span><strong>${{fmt(row[key])}}</strong>`;
+        metrics.appendChild(div);
+      }}
+      table.innerHTML = `<tr><th>Run</th><th>V0</th><th>interval</th><th>detector x</th><th>unconditional transmission</th><th>detector clicks</th><th>absorbed</th><th>survival</th></tr>` +
+        rows.map(r => `<tr><td>${{r.name}}</td><td>${{r.barrier_height}}</td><td>${{r.interval ?? "unmeasured"}}</td><td>${{fmt(r.detector_x)}}</td><td>${{fmt(r.unconditional_transmission_probability)}}</td><td>${{fmt(r.detected_probability)}}</td><td>${{fmt(r.absorbed_probability)}}</td><td>${{fmt(r.survival_weight)}}</td></tr>`).join("");
+    }}
+    heightSelect.addEventListener("change", render);
+    intervalSelect.addEventListener("change", render);
+    render();
+  </script>
+</body>
+</html>
+"""
+    path.write_text(html_text, encoding="utf-8")
+    return path
+
+
+def _write_research_narrative(
+    rows: list[dict[str, float | str | None]], comparison: Path, heatmap: Path, path: Path
+) -> Path:
+    unmeasured = [row for row in rows if row["interval"] is None]
+    measured = [row for row in rows if row["interval"] is not None]
+    strongest = min(measured, key=lambda row: float(row["unconditional_transmission_probability"]))
+    weakest_barrier = max(unmeasured, key=lambda row: float(row["unconditional_transmission_probability"]))
+    lines = [
+        "# Reproducible Zeno Barrier Narrative",
+        "",
+        "## Question",
+        "",
+        "Can repeated no-click observation suppress transmission of a Gaussian wave packet through a finite barrier on a two-dimensional lattice?",
+        "",
+        "## Method",
+        "",
+        "Each run evolves the same packet with a split-step Fourier method. The sweep varies barrier height and measurement interval. Measurements are modeled as no-click projections at a detector region to the right of the barrier, while absorbing boundaries track probability that reaches the edge of the simulation box.",
+        "",
+        "## Figures",
+        "",
+        f"![Comparison]({comparison.name})",
+        "",
+        f"![No-click transmission heatmap]({heatmap.name})",
+        "",
+        "## Result",
+        "",
+        f"The largest unmeasured no-click transmission in this sweep is {float(weakest_barrier['unconditional_transmission_probability']):.6f} for `{weakest_barrier['name']}`. The strongest suppression among measured runs leaves {float(strongest['unconditional_transmission_probability']):.6f} unconditional no-click transmission for `{strongest['name']}`.",
+        "",
+        "## Assumptions",
+        "",
+        "- Periodic FFT evolution is combined with an optional absorbing edge mask to reduce wraparound artifacts.",
+        "- Detector clicks are accumulated separately from boundary absorption.",
+        "- The Zeno signal is interpreted through unconditional no-click branch transmission, not cumulative detector-click probability alone.",
+        "- The generated figures and CSV are reproducible from the committed TOML configs and the `quantum-lab compare` command.",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _write_full_research_narrative(
+    rows: list[dict[str, float | str | None]],
+    zeno_comparison: Path,
+    zeno_heatmap: Path,
+    double_summary: Path,
+    double_config: dict[str, Any],
+    double_metrics: dict[str, Any],
+    path: Path,
+) -> Path:
+    measured = [row for row in rows if row["interval"] is not None]
+    unmeasured = [row for row in rows if row["interval"] is None]
+    strongest = min(measured, key=lambda row: float(row["unconditional_transmission_probability"]))
+    baseline = max(unmeasured, key=lambda row: float(row["unconditional_transmission_probability"]))
+    coherent = float(double_metrics.get("coherent_interference_contrast", 0.0))
+    which_path = float(double_metrics.get("which_path_interference_contrast", 0.0))
+    lines = [
+        "# 2D Quantum Dynamics Research Narrative",
+        "",
+        "## Research Questions",
+        "",
+        "1. Does repeated no-click observation suppress barrier transmission on a two-dimensional lattice?",
+        "2. Does which-path projection reduce double-slit interference contrast?",
+        "",
+        "## Reproducible Inputs",
+        "",
+        "- Zeno sweep CSV: `comparison.csv`",
+        f"- Double-slit run: `{double_config['name']}`",
+        f"- Double-slit grid: {double_config['grid']['n']} x {double_config['grid']['n']}, L={double_config['grid']['length']}",
+        "",
+        "## Zeno Barrier Result",
+        "",
+        f"The unmeasured baseline with the largest transmission is `{baseline['name']}` with unconditional transmission {float(baseline['unconditional_transmission_probability']):.6f}. The strongest measured suppression is `{strongest['name']}` with unconditional no-click transmission {float(strongest['unconditional_transmission_probability']):.6f}.",
+        "",
+        f"![Zeno comparison]({zeno_comparison.name})",
+        "",
+        f"![Zeno heatmap]({zeno_heatmap.name})",
+        "",
+        "## Double-Slit Result",
+        "",
+        f"The coherent screen-profile contrast is {coherent:.6f}; the which-path contrast is {which_path:.6f}. Lower which-path contrast is consistent with measurement suppressing interference structure in the branch-combined probability.",
+        "",
+        f"![Double-slit summary]({double_summary.name})",
+        "",
+        "## Assumptions And Limits",
+        "",
+        "- The solver uses a split-step Fourier method and optional FFT backends; numerical behavior should be checked when changing backend or grid resolution.",
+        "- Absorbing edges reduce wraparound but introduce a boundary-loss diagnostic that should remain small enough for the intended interpretation.",
+        "- The Zeno analysis focuses on unconditional no-click branch transmission rather than raw cumulative detector clicks.",
+        "- The double-slit comparison is an operational which-path projection model, not a full detector-environment model.",
+        "",
+    ]
     path.write_text("\n".join(lines), encoding="utf-8")
     return path

--- a/src/quantum_dynamics_lab/solver.py
+++ b/src/quantum_dynamics_lab/solver.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import cached_property
 
 import numpy as np
 from numpy.typing import NDArray
 
+from .backends import FFTBackend, create_backend
 from .config import BoundaryConfig, SolverConfig
 from .grid import Grid, norm
 
@@ -25,6 +27,7 @@ class SplitStepSolver:
     potential: FloatArray
     config: SolverConfig
     boundary: BoundaryConfig = BoundaryConfig()
+    backend: FFTBackend | None = None
 
     def __post_init__(self) -> None:
         if self.config.dt <= 0:
@@ -50,6 +53,16 @@ class SplitStepSolver:
     def frame_stride(self) -> int:
         return max(1, int(round(self.config.frame_interval / self.config.dt)))
 
+    @cached_property
+    def fft_backend(self) -> FFTBackend:
+        if self.backend is not None:
+            return self.backend
+        return create_backend(self.config.backend)
+
+    @property
+    def backend_name(self) -> str:
+        return self.fft_backend.name
+
     def step(self, psi: ComplexArray) -> ComplexArray:
         return self.step_with_diagnostics(psi).psi
 
@@ -60,7 +73,8 @@ class SplitStepSolver:
         position_half = np.exp(-0.5j * self.potential * dt / hbar)
         kinetic = np.exp(-1j * hbar * self.grid.k2 * dt / (2.0 * mass))
         psi = position_half * psi
-        psi = np.fft.ifft2(np.fft.fft2(psi) * kinetic)
+        backend = self.fft_backend
+        psi = backend.ifft2(backend.fft2(psi) * kinetic)
         psi = (position_half * psi).astype(np.complex128)
         before_absorber = norm(psi, self.grid)
         psi = self.absorber_mask * psi

--- a/tests/test_solver_experiments_cli.py
+++ b/tests/test_solver_experiments_cli.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
-import numpy as np
+import importlib.util
 
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.backends import create_backend
 from quantum_dynamics_lab.cli import main
 from quantum_dynamics_lab.config import (
     BoundaryConfig,
@@ -50,6 +54,16 @@ def test_plane_wave_accumulates_expected_free_phase() -> None:
 
     assert np.max(np.abs(evolved - expected)) < 1e-12
     assert np.isclose(norm(evolved, grid), 1.0)
+
+
+def test_fft_backend_selection_and_missing_optional_errors() -> None:
+    assert create_backend("numpy").name == "numpy"
+    assert create_backend("auto").name in {"numpy", "pyfftw"}
+    if importlib.util.find_spec("cupy") is None:
+        with pytest.raises(RuntimeError, match="cupy is not installed"):
+            create_backend("cupy")
+    else:
+        assert create_backend("cupy").name == "cupy"
 
 
 def test_barrier_zeno_fast_measurement_reduces_detection() -> None:
@@ -146,6 +160,7 @@ def test_cli_run_and_render_smoke(tmp_path) -> None:
     assert (out / "report" / "summary.png").exists()
     assert (out / "report" / "potential.png").exists()
     assert (out / "report" / "report.md").exists()
+    assert (out / "report" / "report.html").exists()
 
 
 def test_research_sweep_scan_expands_variants() -> None:
@@ -217,3 +232,123 @@ measurement_intervals = [0.0, 0.08]
     assert (out / "comparison.png").exists()
     assert (out / "zeno_transmission_heatmap.png").exists()
     assert (out / "report.md").exists()
+    assert (out / "report.html").exists()
+    assert (out / "explorer.html").exists()
+    assert (out / "research_narrative.md").exists()
+
+
+def test_narrative_command_combines_zeno_and_double_slit(tmp_path) -> None:
+    zeno_base = tmp_path / "zeno_base.toml"
+    zeno_base.write_text(
+        """
+name = "small_zeno"
+experiment = "barrier_zeno"
+
+[grid]
+n = 24
+length = 8.0
+
+[wave_packet]
+center = [-2.0, 0.0]
+sigma = 0.45
+momentum = [4.0, 0.0]
+
+[potential]
+kind = "barrier"
+height = 30.0
+barrier_x = 0.0
+barrier_width = 0.25
+
+[solver]
+dt = 0.004
+tf = 0.12
+frame_interval = 0.04
+backend = "numpy"
+
+[measurement]
+kind = "zeno"
+interval = 0.08
+detector_buffer = 0.25
+
+[output]
+render_video = false
+""",
+        encoding="utf-8",
+    )
+    zeno_sweep = tmp_path / "zeno_sweep.toml"
+    zeno_sweep.write_text(
+        """
+name = "small_sweep"
+base_config = "zeno_base.toml"
+
+[scan]
+potential_heights = [30.0]
+measurement_intervals = [0.0, 0.08]
+""",
+        encoding="utf-8",
+    )
+    double_config = tmp_path / "double.toml"
+    double_config.write_text(
+        """
+name = "small_double"
+experiment = "double_slit"
+
+[grid]
+n = 24
+length = 8.0
+
+[wave_packet]
+center = [-2.0, 0.0]
+sigma = 0.45
+momentum = [4.0, 0.0]
+
+[potential]
+kind = "double_slit"
+height = 80.0
+barrier_x = 0.0
+barrier_width = 0.25
+slit_width = 0.45
+slit_separation = 1.1
+
+[solver]
+dt = 0.004
+tf = 0.12
+frame_interval = 0.04
+backend = "numpy"
+
+[measurement]
+kind = "which_path"
+
+[output]
+render_video = false
+""",
+        encoding="utf-8",
+    )
+    zeno_out = tmp_path / "zeno_report"
+    double_out = tmp_path / "double"
+    narrative_out = tmp_path / "narrative"
+
+    assert main(["compare", str(zeno_sweep), "--out", str(zeno_out)]) == 0
+    assert main(["run", str(double_config), "--out", str(double_out)]) == 0
+    assert (
+        main(
+            [
+                "narrative",
+                "--zeno",
+                str(zeno_out),
+                "--double-slit",
+                str(double_out / "run.npz"),
+                "--out",
+                str(narrative_out),
+            ]
+        )
+        == 0
+    )
+
+    narrative = (narrative_out / "research_narrative.md").read_text(encoding="utf-8")
+    assert "Zeno Barrier Result" in narrative
+    assert "Double-Slit Result" in narrative
+    assert (narrative_out / "research_narrative.html").exists()
+    assert (narrative_out / "zeno_comparison.png").exists()
+    assert (narrative_out / "zeno_transmission_heatmap.png").exists()
+    assert (narrative_out / "double_slit_summary.png").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -99,6 +99,40 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-pathfinder"
+version = "1.5.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/53/8fc9b0cdc5b7f62746e6a01b85b6461e5ae27f871010a5fcf8fa6950766d/cuda_pathfinder-1.5.6-py3-none-any.whl", hash = "sha256:7e4c07c117b78ba1fb35dac4c444d21f3677b1b1ff56175c53a8e3025c5b43c0", size = 52972, upload-time = "2026-06-30T00:58:04.34Z" },
+]
+
+[[package]]
+name = "cupy-cuda12x"
+version = "14.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/65/13c173fec4923b9c4e1573344fc4a5585bf0e4efe5d9a5632e9bb18b2a31/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_aarch64.whl", hash = "sha256:5d4c1c74f9f7fc9de0aa5781cf3ec54f9f05143f5761e21a8798772c8eedd0be", size = 145089362, upload-time = "2026-06-01T04:52:05.643Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/5e/ccd2fea320ece269dd7237649da384cad71fbb1ba30937a1eb3311c31b77/cupy_cuda12x-14.1.1-cp311-cp311-manylinux2014_x86_64.whl", hash = "sha256:8889cb83dbb7dbea593e60c85fcc91e21b0ccd10cd5380dfdfaac70b6bd9390a", size = 134012855, upload-time = "2026-06-01T04:52:11.526Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/59/93970d536e8401cf31d8f5602141f1c2edfc304e6d6b8702041688509509/cupy_cuda12x-14.1.1-cp311-cp311-win_amd64.whl", hash = "sha256:e39a081fc4fe2166f95ef8be38fe2a95b2c4decb3ec991b4f26bfc9673d16b17", size = 95336905, upload-time = "2026-06-01T04:52:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6e/290ee2d7cc4ad63d66e67acfd7ff3026f2b648dd04449a1bf88ffaa36b1e/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_aarch64.whl", hash = "sha256:7aae7d3bed37985e2aa39f0914b88ad90dbd3a6141d3e8198d73fce65859013c", size = 144383812, upload-time = "2026-06-01T04:52:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6e/dc03c1ddc940f33b3d32803898e2fdae5c9538a2127a25f499494c84b183/cupy_cuda12x-14.1.1-cp312-cp312-manylinux2014_x86_64.whl", hash = "sha256:a1138f20080489a46209291498cd12f792226d0a57d50c64a586c162a875a069", size = 133516927, upload-time = "2026-06-01T04:52:35.765Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/d4a8045b533af634bc791572e8c87981065e4a27b5d3e09d0d4d285742fd/cupy_cuda12x-14.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:85bebce86ffc25ecf31727b25da7b3793daf07b6fd9952704546af574d250988", size = 95238722, upload-time = "2026-06-01T04:52:46.296Z" },
+    { url = "https://files.pythonhosted.org/packages/30/90/00fe874c47207b26c9b6ac950d0cecc533b4a145491641932df17e573f3c/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:afbb3d1fa9484b0ae20d76372c5939a8c5da327e3fc8711b77b2354566cac355", size = 143920086, upload-time = "2026-06-01T04:52:51.726Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a4/c46ff91dba0dbe2a0a557974faf4c090a3159d6e7296431ca6846038d047/cupy_cuda12x-14.1.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:76ea35469e2aa0a8332b88f72505ea2f7871a0bc8f9b0c87184f57e47c9aa3bf", size = 133071615, upload-time = "2026-06-01T04:52:57.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a0/46778424035ad3fc920d49471f079687a054f74d179142e9520014c2514e/cupy_cuda12x-14.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:64072f4139b44df38215f0519a6badc14138fa0e4bb5b2db44fe94d05f8b9c8b", size = 95219598, upload-time = "2026-06-01T04:53:02.774Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/99/d72336481264c3483b162ea128d58f80abb50009f1df82ca82905e0b8fd7/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_aarch64.whl", hash = "sha256:22d0ff2755a7f29cb225d1d5fb979a73428c5534ea0bca91b0c02698e9948f84", size = 143788629, upload-time = "2026-06-01T04:53:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/77/c43a67e6809e03780d88caf690fa44a8b3152db2d8f848714bec327c9881/cupy_cuda12x-14.1.1-cp314-cp314-manylinux2014_x86_64.whl", hash = "sha256:1059581507343e7cf6231facce30932a195c7aad4fa7771d00e4a252683915a1", size = 132406367, upload-time = "2026-06-01T04:53:16.232Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/dc/96cd37de6da41239e02fc7f17e3364d60f99bd6816673d622916a06113ec/cupy_cuda12x-14.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:e707e0eceee174d323be21652e87bb97be982e6966b5dc241756307df42842aa", size = 95793971, upload-time = "2026-06-01T04:53:21.478Z" },
+    { url = "https://files.pythonhosted.org/packages/20/c6/0ddec1be851de546e883ae3da5f03c1ea69738628b38234dce4362b5e38b/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_aarch64.whl", hash = "sha256:e09897636b7468a90efa1152109f0b19ba49ebc9a423d5dbd4682ed589e57843", size = 144093057, upload-time = "2026-06-01T04:53:28.647Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/80/5e05de89ba61df072aab6f8a6ee3ffeec57db68a0a456825b3b4ce608426/cupy_cuda12x-14.1.1-cp314-cp314t-manylinux2014_x86_64.whl", hash = "sha256:238080487174268d0f09770fe518de7c5b206527bef5c6792aef7ba0626a1c48", size = 132635338, upload-time = "2026-06-01T04:53:35.229Z" },
+]
+
+[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -576,6 +610,45 @@ wheels = [
 ]
 
 [[package]]
+name = "pyfftw"
+version = "0.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/2d/e38439b7f937e8bf91a9ff2b8d9713d0d8e64e980fc00e8d1945b8a5b74b/pyfftw-0.15.1.tar.gz", hash = "sha256:bbcde6d40d165e1cbaf12dde062ebfebe9e43394cac8c166e699ba2c9a4b0461", size = 192838, upload-time = "2025-10-22T19:58:56.683Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/c0/4f1a586eed5eba86c27d6fab4ebed44bbfeedd5209e835c19c6406f96a41/pyfftw-0.15.1-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:fb5283238be3c797b7b91cbb1d549787b9d0495a7d48b828832a3c94fa557f48", size = 3297881, upload-time = "2025-10-22T19:58:20.945Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/c1/02eaaf7a2f7ca26d7b56b6195617979b44b9213f3dcc1a514663a3bbc264/pyfftw-0.15.1-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:f4b42864e95f128a676e27a94025cce074d807a81d48ed423c65aa7403a7729a", size = 1682075, upload-time = "2025-10-22T19:58:22.236Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/23/e3692116f6e903d1d9705d1f948f94ee133512a0b388d05ea0f8adcb0c07/pyfftw-0.15.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e728dbe262182089a6606b7feb5c67bc55b8b385b0c1b60f71d6a891b5f142a", size = 2557646, upload-time = "2025-10-22T19:58:23.345Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/49/affa553caa93928d2f7d814f26939487d37d4068a0ba4d8238c6ba3000b1/pyfftw-0.15.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:294eecf05577b0198e6d041376e016254c4b54040b8a7a330d9d6321b8b30472", size = 3158494, upload-time = "2025-10-22T19:58:24.63Z" },
+    { url = "https://files.pythonhosted.org/packages/88/92/bde713b499fa2062f30f396603bbf09acd0c9c974249638202c931433498/pyfftw-0.15.1-cp311-cp311-win32.whl", hash = "sha256:ed42033aa729520c66500027157525981613a139c2fd4671dd7d52d58cb4b820", size = 2226331, upload-time = "2025-10-22T19:58:26.345Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f4/e0583a68e1114b108354207ce0680b898a4b37c48bd3a8cfc1fd0ec1a476/pyfftw-0.15.1-cp311-cp311-win_amd64.whl", hash = "sha256:e32a30c34f27c24ee602b89b22d9cd453570bf851e7d8f98506185cb5e99ccfc", size = 2634855, upload-time = "2025-10-22T19:58:27.839Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/76/5673561606f45c60ab3da497deead308e2c4b59c2b705334a01b880f0421/pyfftw-0.15.1-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:074926b5fa6a2193771cb4dc5beaa52ea1d629dc40da363d7de7918df5f3e951", size = 3315083, upload-time = "2025-10-22T19:58:28.981Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/fb/5042ad5c4ddc2db89844fc853b6358d36497e44f9d32f3aef9c3fa393182/pyfftw-0.15.1-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2156d7bc72a2e2a1c747767909b1a7ba2bcfde14a51fca3171d7c1f8de6c2f02", size = 1698218, upload-time = "2025-10-22T19:58:30.536Z" },
+    { url = "https://files.pythonhosted.org/packages/df/1c/7b76808da67a3775480f64e93acc0a623aad7682ba83428311de05ebc67a/pyfftw-0.15.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:313340683d5e99b0a36e45b8c2bd92cd86dfbb18917a62e89890927a66bed9e9", size = 2562434, upload-time = "2025-10-22T19:58:31.531Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/43/43fbc63ec6790ce6346e6441e82b54356334641d9d6f099f1ed75d302f2a/pyfftw-0.15.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:900d79c7fa1b27b58ec4240f7cb6d512492a9db9bc8cbd18076ed28c84a63b62", size = 3167162, upload-time = "2025-10-22T19:58:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e1/82d4967ef4ccd8c17e58a9a34fa283436de98c32c08aac4191ef56bf9989/pyfftw-0.15.1-cp312-cp312-win32.whl", hash = "sha256:9c94a6d251f2ceb9d6bb86964c43f9eb9cbd8612a60f41b10c8a64e816f6a2ed", size = 2222298, upload-time = "2025-10-22T19:58:33.795Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/c0/3f4513921fd3cb40986bc6fe4a33e87c5aef671edff483db6f7c4a5f8309/pyfftw-0.15.1-cp312-cp312-win_amd64.whl", hash = "sha256:74fe153d6bec682cd85b5601df09cb84ce6e3cc901172a3ce86da7544e457e4c", size = 2633571, upload-time = "2025-10-22T19:58:35.185Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/f5/5dca09b863e71db438069eb1990526a4409deebc190228177dec3b7cc636/pyfftw-0.15.1-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:a16c4eb45ff5277f8bcb979d43a6a0d7f2e7405dcad984dc45a30064ed487da9", size = 3315212, upload-time = "2025-10-22T19:58:36.273Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c1/1ff9aa930f98c77bbff9cae122e496f1fd7201abac309f1dbcc9fbe5c7ee/pyfftw-0.15.1-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:2b4bad0184546e3129eeda9d07541eca71232f6e431d57c734930d25f06386e8", size = 1698270, upload-time = "2025-10-22T19:58:37.684Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3f/e94d5773429dc076ec4b47d029603de1728a5037024ed3dbcc853cfa72e9/pyfftw-0.15.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1716378d1d102527917b872a5baf15e2e3de52d5200ccc22128816cd71c33148", size = 2559574, upload-time = "2025-10-22T19:58:38.662Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/64/5f773d61cca91a1a741e2403d7191610513d0cca3fc73a41a6941a31fe89/pyfftw-0.15.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:16209de9a244ab7b3337e8ce8d528420ffd05881e7d19e5be21d2546a7e5b2c1", size = 3166906, upload-time = "2025-10-22T19:58:39.986Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8a/dda252557803fde20be41396425a85faf6680eaeed3996e4b765745e9206/pyfftw-0.15.1-cp313-cp313-win32.whl", hash = "sha256:db2a65c59d7a707c55a8f0f38be3916b907429ceed316c6875201b202e22ac99", size = 2222209, upload-time = "2025-10-22T19:58:41.237Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6b/9236a2fb77b01b00b957304d53694de2bf034caac89c1d35ab7fa3421fd9/pyfftw-0.15.1-cp313-cp313-win_amd64.whl", hash = "sha256:dcac51a5a4b8c6600bb2c7edb86d9739860a61bb0b076e20fbf0340919da307d", size = 2633673, upload-time = "2025-10-22T19:58:42.709Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/5c/ec4cef958e936ac61528644825d052c1c486192aeffadf071071a17cd86a/pyfftw-0.15.1-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:c4e49219794bfe99c7db94d0b392c86ff979db4da2d27d444edbc6de1519ddae", size = 3313756, upload-time = "2025-10-22T19:58:44.002Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/39e06bab39edf6473653670c6c25fe971a7b369a2059ddc971ac5f872653/pyfftw-0.15.1-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:489a6364a613935736d43da67791ab4dfcf4875e968a8b46e99983afde7ec960", size = 1697163, upload-time = "2025-10-22T19:58:45.592Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/4d/9ae0dfaf5174a13714cfc5377165de5703230c1df96715cfee9d19fb0b4c/pyfftw-0.15.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379844360c03402f4d2a738fa19924153d5467cdc88aa3752b12bbc1403512b0", size = 2561755, upload-time = "2025-10-22T19:58:46.773Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/bc991e3abf4f6ad9907658e3b282530d345027fa294b510a9eb1fce882c4/pyfftw-0.15.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:398a342a689061bfc4bfe7271a973e093f78176a632fb4e523b3ed5b72dba4c6", size = 3156174, upload-time = "2025-10-22T19:58:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/5d/c0a9782c333e8b5de334285e3adc0542f2265107d0c9b720f5730bc43471/pyfftw-0.15.1-cp314-cp314-win32.whl", hash = "sha256:375ec8b11140eb30262bf9ecfa34d043a42d036c33c66e24bfe734f5aae7ddf0", size = 2245736, upload-time = "2025-10-22T19:58:49.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/c7/ba88f0b5d81ae0732a2cb2900c52924ddfa6b1623e511533c022a558e058/pyfftw-0.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:558c318a1aea81ce2083309c927fd881ccf9c285c5571ce965bb7b18dc4291fd", size = 2660474, upload-time = "2025-10-22T19:58:50.93Z" },
+    { url = "https://files.pythonhosted.org/packages/88/45/a34cd015d16002e748de0e218d24ecc2f30eb9ad073f1c7941a51a796a2e/pyfftw-0.15.1-pp311-pypy311_pp73-macosx_13_0_x86_64.whl", hash = "sha256:41a25b721e79378a3ea29d21d2e6cf25e43c1f44bc0bbf554beccdcdb2b8064e", size = 3278795, upload-time = "2025-10-22T19:58:52.212Z" },
+    { url = "https://files.pythonhosted.org/packages/15/27/0e6195c9c5eeef73a7499772621057aff5ffd04ebb52a71d49cc049a3dad/pyfftw-0.15.1-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e957f5caa7ccc032d17831ce336cb61b93f516ed7da25ea6c9e1086ed2e323f", size = 2570541, upload-time = "2025-10-22T19:58:53.357Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a9/f1d00acce882645198576a94c4b7fff5465f0bb6c4b7bb1005314527c2d0/pyfftw-0.15.1-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:763cd58e858133493db371ed3a63e9e41463cd40965e2375a079947c2d96805f", size = 2625398, upload-time = "2025-10-22T19:58:54.893Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -631,6 +704,14 @@ dependencies = [
     { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
+[package.optional-dependencies]
+cuda12 = [
+    { name = "cupy-cuda12x" },
+]
+fftw = [
+    { name = "pyfftw" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -638,9 +719,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cupy-cuda12x", marker = "extra == 'cuda12'", specifier = ">=13" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=2.0" },
+    { name = "pyfftw", marker = "extra == 'fftw'", specifier = ">=0.15" },
 ]
+provides-extras = ["fftw", "cuda12"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8.0" }]


### PR DESCRIPTION
## Summary
- add optional FFT backend selection with NumPy, pyFFTW, CuPy, and auto fallback support
- add optional uv extras for pyFFTW and CUDA 12 CuPy installs
- enrich run and sweep reports with Markdown and self-contained HTML output
- generate `explorer.html` for static browser-based Zeno parameter inspection
- add `quantum-lab narrative` to combine Zeno sweep artifacts and double-slit artifacts into a research narrative
- keep double-slit example quick by disabling default video rendering

## Tracking
Closes #14
Closes #15
Closes #16
Closes #17

## Validation
- `uv run pytest`
- `uv run python -m compileall -q src tests`
- `uv run quantum-lab compare examples/zeno_research_sweep.toml --out reports/zeno_research_sweep`
- `uv run quantum-lab run examples/double_slit.toml --out runs/double_slit_narrative`
- `uv run quantum-lab narrative --zeno reports/zeno_research_sweep --double-slit runs/double_slit_narrative/run.npz --out reports/research_narrative`
- `uv run quantum-lab run examples/free_packet.toml --out runs/free_packet_ci_smoke`

## Generated local artifacts
- `reports/zeno_research_sweep/report.html`
- `reports/zeno_research_sweep/explorer.html`
- `reports/research_narrative/research_narrative.html`