### PR TITLE
Add physics validation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ uv run quantum-lab compare examples/zeno_sweep.toml --out reports/zeno_sweep
 uv run quantum-lab compare examples/zeno_research_sweep.toml --out reports/zeno_research_sweep
 uv run quantum-lab run examples/double_slit.toml --out runs/double_slit
 uv run quantum-lab narrative --zeno reports/zeno_research_sweep --double-slit runs/double_slit/run.npz --out reports/research_narrative
+uv run quantum-lab validate examples/validation_suite.toml --out reports/validation_suite
 uv run quantum-lab render runs/free_packet/run.npz --out reports/free_packet
 ```
 
@@ -51,6 +52,11 @@ Optional FFT backends can be selected in `[solver]` with `backend = "numpy"`,
 installed and otherwise falls back to NumPy; CuPy and pyFFTW remain optional
 dependencies. Install them with `uv sync --extra fftw` or
 `uv sync --extra cuda12` when the local machine supports those runtimes.
+
+The validation workflow writes `validation_metrics.json`,
+`validation_report.md`, `validation_report.html`, and `validation_summary.png`.
+It checks norm conservation, free Gaussian dispersion, barrier transmission
+trends, Zeno no-click transmission trends, and optional backend parity.
 
 ---
 

--- a/examples/validation_suite.toml
+++ b/examples/validation_suite.toml
@@ -1,0 +1,38 @@
+name = "physics_validation_suite"
+
+[[norm_cases]]
+name = "norm_n32_dt002"
+n = 32
+dt = 0.002
+tf = 0.08
+tolerance = 1e-8
+
+[[norm_cases]]
+name = "norm_n48_dt0015"
+n = 48
+dt = 0.0015
+tf = 0.06
+tolerance = 1e-8
+
+[[dispersion_cases]]
+name = "free_gaussian_dispersion"
+n = 48
+dt = 0.0015
+tf = 0.12
+sigma = 0.7
+tolerance = 0.35
+
+[barrier_case]
+name = "barrier_height_sweep"
+heights = [20.0, 40.0, 60.0]
+tolerance = 1e-6
+
+[zeno_case]
+name = "zeno_interval_sweep"
+intervals = [0.0, 0.06, 0.12, 0.24]
+tolerance = 1e-6
+
+[backend_case]
+name = "backend_parity"
+backends = ["numpy", "pyfftw", "cupy"]
+tolerance = 1e-10

--- a/src/quantum_dynamics_lab/cli.py
+++ b/src/quantum_dynamics_lab/cli.py
@@ -7,6 +7,7 @@ from .artifacts import save_run, write_metrics
 from .config import apply_sweep_variant, load_experiment_config, load_sweep_config
 from .experiments import run_experiment
 from .render import render_comparison, render_research_narrative, render_run
+from .validation import load_validation_config, run_validation
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -33,6 +34,12 @@ def main(argv: list[str] | None = None) -> int:
     narrative_parser.add_argument("--zeno", type=Path, required=True)
     narrative_parser.add_argument("--double-slit", type=Path, required=True)
     narrative_parser.add_argument("--out", type=Path, required=True)
+
+    validate_parser = subparsers.add_parser(
+        "validate", help="Run physics validation benchmarks"
+    )
+    validate_parser.add_argument("config", type=Path)
+    validate_parser.add_argument("--out", type=Path, required=True)
 
     args = parser.parse_args(argv)
     if args.command == "run":
@@ -70,6 +77,11 @@ def main(argv: list[str] | None = None) -> int:
         render_research_narrative(args.zeno, args.double_slit, args.out)
         print(args.out)
         return 0
+    if args.command == "validate":
+        config = load_validation_config(args.config)
+        metrics = run_validation(config, args.out)
+        print(args.out)
+        return 0 if metrics["passed"] else 1
     return 2
 
 

--- a/src/quantum_dynamics_lab/validation.py
+++ b/src/quantum_dynamics_lab/validation.py
@@ -1,0 +1,528 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+import json
+import tomllib
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from .backends import create_backend
+from .config import (
+    BoundaryConfig,
+    ExperimentConfig,
+    GridConfig,
+    MeasurementConfig,
+    PotentialConfig,
+    SolverConfig,
+    WavePacketConfig,
+)
+from .experiments import run_experiment
+from .grid import make_grid, normalize
+from .solver import SplitStepSolver
+
+
+@dataclass(frozen=True)
+class NormCase:
+    name: str
+    n: int
+    dt: float
+    tf: float
+    tolerance: float = 1e-8
+
+
+@dataclass(frozen=True)
+class DispersionCase:
+    name: str
+    n: int
+    dt: float
+    tf: float
+    sigma: float
+    tolerance: float = 0.35
+
+
+@dataclass(frozen=True)
+class BarrierCase:
+    name: str
+    heights: tuple[float, ...]
+    tolerance: float = 1e-6
+
+
+@dataclass(frozen=True)
+class ZenoCase:
+    name: str
+    intervals: tuple[float, ...]
+    tolerance: float = 1e-6
+
+
+@dataclass(frozen=True)
+class BackendCase:
+    name: str
+    backends: tuple[str, ...] = ("numpy", "pyfftw", "cupy")
+    tolerance: float = 1e-10
+
+
+@dataclass(frozen=True)
+class ValidationConfig:
+    name: str = "validation_suite"
+    norm_cases: tuple[NormCase, ...] = field(default_factory=tuple)
+    dispersion_cases: tuple[DispersionCase, ...] = field(default_factory=tuple)
+    barrier_case: BarrierCase | None = None
+    zeno_case: ZenoCase | None = None
+    backend_case: BackendCase | None = None
+
+
+def load_validation_config(path: str | Path) -> ValidationConfig:
+    path = Path(path)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    norm_cases = tuple(
+        NormCase(
+            name=str(item["name"]),
+            n=int(item["n"]),
+            dt=float(item["dt"]),
+            tf=float(item["tf"]),
+            tolerance=float(item.get("tolerance", NormCase.tolerance)),
+        )
+        for item in data.get("norm_cases", [])
+    )
+    dispersion_cases = tuple(
+        DispersionCase(
+            name=str(item["name"]),
+            n=int(item["n"]),
+            dt=float(item["dt"]),
+            tf=float(item["tf"]),
+            sigma=float(item["sigma"]),
+            tolerance=float(item.get("tolerance", DispersionCase.tolerance)),
+        )
+        for item in data.get("dispersion_cases", [])
+    )
+    barrier_data = data.get("barrier_case")
+    barrier_case = (
+        None
+        if barrier_data is None
+        else BarrierCase(
+            name=str(barrier_data.get("name", "barrier_height_sweep")),
+            heights=tuple(float(value) for value in barrier_data["heights"]),
+            tolerance=float(barrier_data.get("tolerance", BarrierCase.tolerance)),
+        )
+    )
+    zeno_data = data.get("zeno_case")
+    zeno_case = (
+        None
+        if zeno_data is None
+        else ZenoCase(
+            name=str(zeno_data.get("name", "zeno_interval_sweep")),
+            intervals=tuple(float(value) for value in zeno_data["intervals"]),
+            tolerance=float(zeno_data.get("tolerance", ZenoCase.tolerance)),
+        )
+    )
+    backend_data = data.get("backend_case")
+    backend_case = (
+        None
+        if backend_data is None
+        else BackendCase(
+            name=str(backend_data.get("name", "backend_parity")),
+            backends=tuple(str(value) for value in backend_data.get("backends", BackendCase.backends)),
+            tolerance=float(backend_data.get("tolerance", BackendCase.tolerance)),
+        )
+    )
+    return ValidationConfig(
+        name=str(data.get("name", path.stem)),
+        norm_cases=norm_cases,
+        dispersion_cases=dispersion_cases,
+        barrier_case=barrier_case,
+        zeno_case=zeno_case,
+        backend_case=backend_case,
+    )
+
+
+def run_validation(config: ValidationConfig, out_dir: str | Path) -> dict[str, Any]:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    results: list[dict[str, Any]] = []
+
+    for case in config.norm_cases:
+        results.append(_validate_norm(case))
+    for case in config.dispersion_cases:
+        results.append(_validate_dispersion(case))
+    if config.barrier_case is not None:
+        results.append(_validate_barrier(config.barrier_case))
+    if config.zeno_case is not None:
+        results.append(_validate_zeno(config.zeno_case))
+    if config.backend_case is not None:
+        results.append(_validate_backends(config.backend_case))
+
+    metrics = {
+        "name": config.name,
+        "passed": all(result["passed"] for result in results),
+        "results": results,
+        "config": asdict(config),
+    }
+    (out_dir / "validation_metrics.json").write_text(
+        json.dumps(metrics, indent=2, sort_keys=True), encoding="utf-8"
+    )
+    _plot_validation(metrics, out_dir / "validation_summary.png")
+    _plot_convergence(metrics, out_dir)
+    report = _write_validation_report(metrics, out_dir / "validation_report.md")
+    _write_validation_html(report, out_dir / "validation_report.html")
+    return metrics
+
+
+def _validate_norm(case: NormCase) -> dict[str, Any]:
+    result = run_experiment(
+        ExperimentConfig(
+            name=case.name,
+            experiment="free_packet",
+            grid=GridConfig(n=case.n, length=8.0),
+            wave_packet=WavePacketConfig(center=(-1.5, 0.0), sigma=0.5, momentum=(2.0, 0.5)),
+            potential=PotentialConfig(kind="free"),
+            solver=SolverConfig(dt=case.dt, tf=case.tf, frame_interval=case.tf),
+            boundary=BoundaryConfig(kind="periodic"),
+        )
+    )
+    drift = float(np.max(np.abs(result.arrays["norm"] - 1.0)))
+    return {
+        "name": case.name,
+        "kind": "norm_conservation",
+        "value": drift,
+        "tolerance": case.tolerance,
+        "passed": drift <= case.tolerance,
+        "details": {"n": case.n, "dt": case.dt, "tf": case.tf},
+    }
+
+
+def _validate_dispersion(case: DispersionCase) -> dict[str, Any]:
+    result = run_experiment(
+        ExperimentConfig(
+            name=case.name,
+            experiment="free_packet",
+            grid=GridConfig(n=case.n, length=10.0),
+            wave_packet=WavePacketConfig(center=(0.0, 0.0), sigma=case.sigma, momentum=(0.0, 0.0)),
+            potential=PotentialConfig(kind="free"),
+            solver=SolverConfig(dt=case.dt, tf=case.tf, frame_interval=case.tf),
+            boundary=BoundaryConfig(kind="periodic"),
+        )
+    )
+    probability = np.abs(result.arrays["psi_frames"][-1]) ** 2
+    grid = result.grid
+    variance_x = float(np.sum(probability * grid.X * grid.X) * grid.dx * grid.dy)
+    initial_variance = case.sigma * case.sigma
+    expected_variance = initial_variance + (case.tf * case.tf) / (4.0 * initial_variance)
+    relative_error = abs(variance_x - expected_variance) / expected_variance
+    return {
+        "name": case.name,
+        "kind": "free_gaussian_dispersion",
+        "value": relative_error,
+        "tolerance": case.tolerance,
+        "passed": relative_error <= case.tolerance,
+        "details": {
+            "n": case.n,
+            "dt": case.dt,
+            "tf": case.tf,
+            "sigma": case.sigma,
+            "variance_x": variance_x,
+            "expected_variance": expected_variance,
+        },
+    }
+
+
+def _validate_barrier(case: BarrierCase) -> dict[str, Any]:
+    transmissions = []
+    for height in case.heights:
+        result = run_experiment(_barrier_config(name=f"{case.name}_h{height:g}", height=height))
+        transmissions.append(float(result.metrics["final_unconditional_transmission_probability"]))
+    monotone = all(
+        earlier + case.tolerance >= later
+        for earlier, later in zip(transmissions, transmissions[1:])
+    )
+    return {
+        "name": case.name,
+        "kind": "barrier_transmission_monotonicity",
+        "value": max(
+            [0.0]
+            + [later - earlier for earlier, later in zip(transmissions, transmissions[1:])]
+        ),
+        "tolerance": case.tolerance,
+        "passed": monotone,
+        "details": {"heights": list(case.heights), "transmissions": transmissions},
+    }
+
+
+def _validate_zeno(case: ZenoCase) -> dict[str, Any]:
+    transmissions = []
+    for interval in case.intervals:
+        measurement = (
+            MeasurementConfig(kind="none")
+            if interval <= 0
+            else MeasurementConfig(kind="zeno", interval=interval, detector_buffer=0.25)
+        )
+        result = run_experiment(
+            _barrier_config(name=f"{case.name}_dt{interval:g}", height=40.0, measurement=measurement)
+        )
+        transmissions.append(float(result.metrics["final_unconditional_transmission_probability"]))
+    unmeasured = transmissions[0]
+    measured = transmissions[1:]
+    suppresses = all(value <= unmeasured + case.tolerance for value in measured)
+    frequent_first = all(
+        earlier <= later + case.tolerance
+        for earlier, later in zip(measured, measured[1:])
+    )
+    return {
+        "name": case.name,
+        "kind": "zeno_no_click_transmission",
+        "value": max([0.0] + [value - unmeasured for value in measured]),
+        "tolerance": case.tolerance,
+        "passed": suppresses and frequent_first,
+        "details": {"intervals": list(case.intervals), "transmissions": transmissions},
+    }
+
+
+def _validate_backends(case: BackendCase) -> dict[str, Any]:
+    grid = make_grid(GridConfig(n=24, length=8.0))
+    rng = np.random.default_rng(7)
+    psi0 = normalize(
+        (rng.normal(size=(grid.n, grid.n)) + 1j * rng.normal(size=(grid.n, grid.n))).astype(
+            np.complex128
+        ),
+        grid,
+    )
+    potential = np.zeros((grid.n, grid.n), dtype=np.float64)
+    solver_config = SolverConfig(dt=0.004, tf=0.004, frame_interval=0.004, backend="numpy")
+    reference = SplitStepSolver(grid, potential, solver_config).step(psi0)
+    comparisons = []
+    for backend_name in case.backends:
+        if backend_name == "numpy":
+            continue
+        try:
+            backend = create_backend(backend_name)
+        except RuntimeError as exc:
+            comparisons.append({"backend": backend_name, "skipped": True, "reason": str(exc)})
+            continue
+        candidate = SplitStepSolver(grid, potential, solver_config, backend=backend).step(psi0)
+        comparisons.append(
+            {
+                "backend": backend_name,
+                "skipped": False,
+                "max_abs_error": float(np.max(np.abs(candidate - reference))),
+            }
+        )
+    active_errors = [
+        item["max_abs_error"]
+        for item in comparisons
+        if not item.get("skipped", False)
+    ]
+    max_error = max([0.0] + active_errors)
+    return {
+        "name": case.name,
+        "kind": "backend_parity",
+        "value": max_error,
+        "tolerance": case.tolerance,
+        "passed": max_error <= case.tolerance,
+        "details": {"comparisons": comparisons},
+    }
+
+
+def _barrier_config(
+    name: str, height: float, measurement: MeasurementConfig | None = None
+) -> ExperimentConfig:
+    return ExperimentConfig(
+        name=name,
+        experiment="barrier_zeno",
+        grid=GridConfig(n=40, length=8.0),
+        wave_packet=WavePacketConfig(center=(-2.4, 0.0), sigma=0.45, momentum=(4.5, 0.0)),
+        potential=PotentialConfig(kind="barrier", height=height, barrier_x=0.0, barrier_width=0.25),
+        solver=SolverConfig(dt=0.002, tf=0.9, frame_interval=0.09),
+        boundary=BoundaryConfig(kind="absorbing", width=1.0, strength=4.0),
+        measurement=measurement or MeasurementConfig(kind="none"),
+    )
+
+
+def _plot_validation(metrics: dict[str, Any], path: Path) -> Path:
+    results = metrics["results"]
+    labels = [result["name"] for result in results]
+    values = [float(result["value"]) for result in results]
+    tolerances = [float(result["tolerance"]) for result in results]
+    colors = ["#2ca25f" if result["passed"] else "#de2d26" for result in results]
+    fig, ax = plt.subplots(figsize=(max(7, len(labels) * 1.2), 4.5))
+    x = np.arange(len(labels))
+    ax.bar(x, values, color=colors, label="observed")
+    ax.scatter(x, tolerances, color="#1f2933", marker="_", s=140, label="tolerance")
+    ax.set_xticks(x, labels, rotation=25, ha="right")
+    ax.set_ylabel("validation metric")
+    ax.set_title("Physics validation summary")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+    return path
+
+
+def _plot_convergence(metrics: dict[str, Any], out_dir: Path) -> None:
+    norm_results = [
+        result for result in metrics["results"] if result["kind"] == "norm_conservation"
+    ]
+    if norm_results:
+        labels = [f"N={result['details']['n']}, dt={result['details']['dt']}" for result in norm_results]
+        _plot_metric_series(
+            labels,
+            [float(result["value"]) for result in norm_results],
+            [float(result["tolerance"]) for result in norm_results],
+            "Norm drift across grid/time-step choices",
+            "max |norm - 1|",
+            out_dir / "norm_convergence.png",
+        )
+
+    dispersion_results = [
+        result for result in metrics["results"] if result["kind"] == "free_gaussian_dispersion"
+    ]
+    if dispersion_results:
+        labels = [
+            f"N={result['details']['n']}, dt={result['details']['dt']}" for result in dispersion_results
+        ]
+        _plot_metric_series(
+            labels,
+            [float(result["value"]) for result in dispersion_results],
+            [float(result["tolerance"]) for result in dispersion_results],
+            "Free Gaussian dispersion error",
+            "relative variance error",
+            out_dir / "dispersion_error.png",
+        )
+
+    for result in metrics["results"]:
+        if result["kind"] == "barrier_transmission_monotonicity":
+            _plot_line_series(
+                result["details"]["heights"],
+                result["details"]["transmissions"],
+                "Barrier transmission by potential height",
+                "barrier height",
+                "transmission probability",
+                out_dir / "barrier_transmission.png",
+            )
+        if result["kind"] == "zeno_no_click_transmission":
+            _plot_line_series(
+                result["details"]["intervals"],
+                result["details"]["transmissions"],
+                "Zeno no-click transmission by measurement interval",
+                "measurement interval",
+                "unconditional transmission probability",
+                out_dir / "zeno_transmission.png",
+            )
+
+
+def _plot_metric_series(
+    labels: list[str],
+    values: list[float],
+    tolerances: list[float],
+    title: str,
+    ylabel: str,
+    path: Path,
+) -> None:
+    fig, ax = plt.subplots(figsize=(max(6, len(labels) * 1.4), 4.0))
+    x = np.arange(len(labels))
+    ax.plot(x, values, marker="o", color="#2b6cb0", label="observed")
+    ax.plot(x, tolerances, marker="_", color="#9f1239", linestyle="none", markersize=12, label="tolerance")
+    ax.set_xticks(x, labels, rotation=20, ha="right")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+
+
+def _plot_line_series(
+    x_values: list[float],
+    y_values: list[float],
+    title: str,
+    xlabel: str,
+    ylabel: str,
+    path: Path,
+) -> None:
+    fig, ax = plt.subplots(figsize=(6, 4.0))
+    ax.plot(x_values, y_values, marker="o", color="#2f855a")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(path, dpi=160)
+    plt.close(fig)
+
+
+def _write_validation_report(metrics: dict[str, Any], path: Path) -> Path:
+    lines = [
+        f"# {metrics['name']} validation report",
+        "",
+        f"Overall status: **{'PASS' if metrics['passed'] else 'FAIL'}**",
+        "",
+    ]
+    for alt, filename in (
+        ("Validation summary", "validation_summary.png"),
+        ("Norm convergence", "norm_convergence.png"),
+        ("Dispersion error", "dispersion_error.png"),
+        ("Barrier transmission", "barrier_transmission.png"),
+        ("Zeno transmission", "zeno_transmission.png"),
+    ):
+        if (path.parent / filename).exists():
+            lines.extend([f"![{alt}]({filename})", ""])
+    lines.extend(
+        [
+            "| Check | Kind | Value | Tolerance | Status |",
+            "| --- | --- | ---: | ---: | --- |",
+        ]
+    )
+    for result in metrics["results"]:
+        status = "PASS" if result["passed"] else "FAIL"
+        lines.append(
+            f"| {result['name']} | {result['kind']} | {float(result['value']):.6g} | "
+            f"{float(result['tolerance']):.6g} | {status} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Interpretation Notes",
+            "",
+            "- Norm checks report maximum deviation from unit total probability.",
+            "- Dispersion checks compare measured Gaussian variance against the free-particle analytic variance.",
+            "- Barrier checks require transmission to not increase as barrier height rises.",
+            "- Zeno checks require measured no-click transmission to stay below the unmeasured baseline and increase as measurements become less frequent.",
+            "- Backend checks skip unavailable optional packages and compare installed backends against NumPy.",
+            "",
+        ]
+    )
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _write_validation_html(markdown_path: Path, html_path: Path) -> Path:
+    # Keep this local to avoid depending on the report renderer's private helpers.
+    markdown = markdown_path.read_text(encoding="utf-8")
+    lines = []
+    for line in markdown.splitlines():
+        if line.startswith("# "):
+            lines.append(f"<h1>{line[2:]}</h1>")
+        elif line.startswith("## "):
+            lines.append(f"<h2>{line[3:]}</h2>")
+        elif line.startswith("![") and "](" in line:
+            alt, src = line[2:-1].split("](", 1)
+            lines.append(f'<p><img src="{src}" alt="{alt}"></p>')
+        elif line.startswith("|"):
+            continue
+        elif line.startswith("- "):
+            lines.append(f"<li>{line[2:]}</li>")
+        elif line.strip():
+            lines.append(f"<p>{line}</p>")
+    html_path.write_text(
+        "<!doctype html><html><head><meta charset=\"utf-8\"><title>Validation Report</title>"
+        "<style>body{font-family:system-ui,sans-serif;max-width:960px;margin:2rem auto;padding:0 1rem;}"
+        "img{max-width:100%;height:auto;border:1px solid #ddd}</style></head><body>"
+        + "\n".join(lines)
+        + "</body></html>",
+        encoding="utf-8",
+    )
+    return html_path

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+
+from quantum_dynamics_lab.cli import main
+from quantum_dynamics_lab.validation import load_validation_config, run_validation
+
+
+def test_validation_config_loads_example() -> None:
+    config = load_validation_config("examples/validation_suite.toml")
+
+    assert config.name == "physics_validation_suite"
+    assert len(config.norm_cases) == 2
+    assert config.barrier_case is not None
+    assert config.zeno_case is not None
+    assert config.backend_case is not None
+
+
+def test_validation_runner_writes_artifacts(tmp_path) -> None:
+    config_path = tmp_path / "validation.toml"
+    config_path.write_text(
+        """
+name = "small_validation"
+
+[[norm_cases]]
+name = "norm_small"
+n = 24
+dt = 0.004
+tf = 0.04
+tolerance = 1e-8
+
+[[dispersion_cases]]
+name = "dispersion_small"
+n = 32
+dt = 0.004
+tf = 0.04
+sigma = 0.7
+tolerance = 0.5
+
+[barrier_case]
+name = "barrier_small"
+heights = [20.0, 40.0]
+tolerance = 1e-6
+
+[zeno_case]
+name = "zeno_small"
+intervals = [0.0, 0.06, 0.12]
+tolerance = 1e-6
+
+[backend_case]
+name = "backend_small"
+backends = ["numpy", "pyfftw", "cupy"]
+tolerance = 1e-10
+""",
+        encoding="utf-8",
+    )
+    out = tmp_path / "validation"
+
+    assert main(["validate", str(config_path), "--out", str(out)]) == 0
+
+    metrics = json.loads((out / "validation_metrics.json").read_text(encoding="utf-8"))
+    assert metrics["passed"] is True
+    assert {result["kind"] for result in metrics["results"]} == {
+        "norm_conservation",
+        "free_gaussian_dispersion",
+        "barrier_transmission_monotonicity",
+        "zeno_no_click_transmission",
+        "backend_parity",
+    }
+    assert (out / "validation_report.md").exists()
+    assert (out / "validation_report.html").exists()
+    assert (out / "validation_summary.png").exists()
+    assert (out / "norm_convergence.png").exists()
+    assert (out / "dispersion_error.png").exists()
+    assert (out / "barrier_transmission.png").exists()
+    assert (out / "zeno_transmission.png").exists()
+
+
+def test_run_validation_returns_failed_status_for_tight_tolerance(tmp_path) -> None:
+    config_path = tmp_path / "validation.toml"
+    config_path.write_text(
+        """
+name = "expected_failure"
+
+[[dispersion_cases]]
+name = "too_tight"
+n = 24
+dt = 0.004
+tf = 0.08
+sigma = 0.7
+tolerance = 0.0
+""",
+        encoding="utf-8",
+    )
+    config = load_validation_config(config_path)
+    metrics = run_validation(config, tmp_path / "out")
+
+    assert metrics["passed"] is False


### PR DESCRIPTION
## Summary
- add a configurable physics validation CLI workflow
- validate norm conservation, free Gaussian dispersion, barrier transmission trends, Zeno no-click monotonicity, and optional backend parity
- write validation metrics, Markdown/HTML reports, and convergence/sweep plots

## Tests
- uv run python -m compileall -q src tests
- uv run pytest
- uv run quantum-lab validate examples/validation_suite.toml --out reports/validation_suite

Closes #20