### PR TITLE
Add comparative dashboard workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,16 @@ uv sync --dev --extra ui
 uv run --extra ui streamlit run apps/streamlit_dashboard.py
 ```
 
-The dashboard provides parameter controls for free-packet and barrier/Zeno
-experiments, a saved-frame viewer for probability density and phase, norm and
-probability diagnostics, and access to the generated NPZ and report artifacts.
-Its validation workspace runs the same physics benchmarks as
-`quantum-lab validate` and displays their pass/fail results and convergence
-plots. Dashboard output is saved under `runs/dashboard/` and
+The dashboard provides parameter controls for free-packet, barrier/Zeno, and
+double-slit experiments, a saved-frame viewer for probability density and
+phase, norm and probability diagnostics, and access to the generated NPZ and
+report artifacts. Double-slit runs compare coherent and which-path densities,
+screen profiles, and interference contrast. The Zeno Sweep workspace runs a
+bounded grid of barrier heights and measurement intervals, including an
+unmeasured baseline, and generates the same CSV, heatmap, and HTML report used
+by the CLI comparison workflow. The validation workspace runs the same physics
+benchmarks as `quantum-lab validate` and displays their pass/fail results and
+convergence plots. Dashboard output is saved under `runs/dashboard/` and
 `reports/dashboard/`, which remain ignored by Git.
 
 The new solver uses a NumPy Strang split-step Fourier method with periodic

--- a/apps/streamlit_dashboard.py
+++ b/apps/streamlit_dashboard.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 import json
 
@@ -8,11 +9,14 @@ import streamlit as st
 from quantum_dynamics_lab.dashboard import (
     DashboardParameters,
     DashboardRun,
+    DashboardSweep,
     experiment_summary,
     plot_diagnostic_panels,
+    plot_double_slit_panels,
     plot_field_panels,
     run_dashboard_experiment,
     run_dashboard_validation,
+    run_dashboard_zeno_sweep,
     timestamped_output_dir,
 )
 
@@ -25,7 +29,9 @@ ROOT = Path(__file__).resolve().parents[1]
 def main() -> None:
     st.set_page_config(page_title="2D Quantum Dynamics Lab", layout="wide")
     st.title("2D Quantum Dynamics Lab")
-    experiment_tab, validation_tab = st.tabs(["Experiment", "Validation"])
+    experiment_tab, sweep_tab, validation_tab = st.tabs(
+        ["Experiment", "Zeno Sweep", "Validation"]
+    )
 
     parameters, run_requested = _experiment_controls()
     with experiment_tab:
@@ -44,6 +50,9 @@ def main() -> None:
         else:
             _show_experiment(dashboard_run)
 
+    with sweep_tab:
+        _zeno_sweep_workspace(parameters)
+
     with validation_tab:
         _validation_workspace()
 
@@ -53,23 +62,70 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
         st.header("Experiment setup")
         mode = st.segmented_control(
             "Experiment",
-            ["Free packet", "Barrier / Zeno"],
+            ["Free packet", "Barrier / Zeno", "Double slit"],
             default="Barrier / Zeno",
             width="stretch",
         )
         is_barrier = mode == "Barrier / Zeno"
+        is_double_slit = mode == "Double slit"
+        experiment = (
+            "double_slit"
+            if is_double_slit
+            else "barrier_zeno"
+            if is_barrier
+            else "free_packet"
+        )
+        mode_defaults = (
+            {
+                "grid_n": 64,
+                "dt": 0.002,
+                "tf": 1.2,
+                "center_x": -3.2,
+                "sigma": 0.45,
+                "momentum_x": 6.0,
+            }
+            if is_double_slit
+            else {
+                "grid_n": 48,
+                "dt": 0.004,
+                "tf": 0.8,
+                "center_x": -2.5,
+                "sigma": 0.5,
+                "momentum_x": 4.5,
+            }
+        )
 
         st.subheader("Grid and solver")
-        grid_n = st.select_slider("Grid points per axis", [32, 48, 64, 96], value=48)
+        grid_n = st.select_slider(
+            "Grid points per axis",
+            [32, 48, 64, 96],
+            value=mode_defaults["grid_n"],
+            key=f"{experiment}_grid_n",
+        )
         grid_length = st.number_input(
-            "Domain length", min_value=4.0, max_value=24.0, value=10.0, step=1.0
+            "Domain length",
+            min_value=4.0,
+            max_value=24.0,
+            value=10.0,
+            step=1.0,
+            key=f"{experiment}_grid_length",
         )
         dt = st.number_input(
-            "Time step", min_value=0.0005, max_value=0.02, value=0.004, step=0.0005,
+            "Time step",
+            min_value=0.0005,
+            max_value=0.02,
+            value=mode_defaults["dt"],
+            step=0.0005,
             format="%.4f",
+            key=f"{experiment}_dt",
         )
         tf = st.number_input(
-            "Final time", min_value=0.04, max_value=3.0, value=0.8, step=0.1
+            "Final time",
+            min_value=0.04,
+            max_value=3.0,
+            value=mode_defaults["tf"],
+            step=0.1,
+            key=f"{experiment}_tf",
         )
         frame_interval = st.number_input(
             "Saved-frame interval",
@@ -78,25 +134,51 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
             value=min(0.04, float(tf)),
             step=float(dt),
             format="%.4f",
+            key=f"{experiment}_frame_interval",
         )
 
         st.subheader("Wave packet")
         center_columns = st.columns(2)
         center_x = center_columns[0].number_input(
-            "Center x", min_value=-10.0, max_value=10.0, value=-2.5, step=0.25
+            "Center x",
+            min_value=-10.0,
+            max_value=10.0,
+            value=mode_defaults["center_x"],
+            step=0.25,
+            key=f"{experiment}_center_x",
         )
         center_y = center_columns[1].number_input(
-            "Center y", min_value=-10.0, max_value=10.0, value=0.0, step=0.25
+            "Center y",
+            min_value=-10.0,
+            max_value=10.0,
+            value=0.0,
+            step=0.25,
+            key=f"{experiment}_center_y",
         )
         sigma = st.number_input(
-            "Packet sigma", min_value=0.15, max_value=2.0, value=0.5, step=0.05
+            "Packet sigma",
+            min_value=0.15,
+            max_value=2.0,
+            value=mode_defaults["sigma"],
+            step=0.05,
+            key=f"{experiment}_sigma",
         )
         momentum_columns = st.columns(2)
         momentum_x = momentum_columns[0].number_input(
-            "Momentum x", min_value=-10.0, max_value=10.0, value=4.5, step=0.5
+            "Momentum x",
+            min_value=-10.0,
+            max_value=10.0,
+            value=mode_defaults["momentum_x"],
+            step=0.5,
+            key=f"{experiment}_momentum_x",
         )
         momentum_y = momentum_columns[1].number_input(
-            "Momentum y", min_value=-10.0, max_value=10.0, value=0.0, step=0.5
+            "Momentum y",
+            min_value=-10.0,
+            max_value=10.0,
+            value=0.0,
+            step=0.5,
+            key=f"{experiment}_momentum_y",
         )
 
         barrier_height = 40.0
@@ -104,7 +186,10 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
         barrier_width = 0.25
         measurement_kind = "none"
         measurement_interval: float | None = None
+        measurement_time: float | None = None
         detector_buffer = 0.25
+        slit_width = 0.45
+        slit_separation = 1.2
         if is_barrier:
             st.subheader("Barrier and measurement")
             barrier_height = st.number_input(
@@ -138,6 +223,45 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
                 value=0.25,
                 step=0.05,
             )
+        elif is_double_slit:
+            st.subheader("Slit geometry and measurement")
+            barrier_height = st.number_input(
+                "Wall height",
+                min_value=0.0,
+                max_value=300.0,
+                value=120.0,
+                step=10.0,
+            )
+            barrier_columns = st.columns(2)
+            barrier_x = barrier_columns[0].number_input(
+                "Wall x", min_value=-4.0, max_value=4.0, value=0.0, step=0.25
+            )
+            barrier_width = barrier_columns[1].number_input(
+                "Wall width", min_value=0.05, max_value=2.0, value=0.25, step=0.05
+            )
+            slit_columns = st.columns(2)
+            slit_width = slit_columns[0].number_input(
+                "Slit width", min_value=0.1, max_value=2.0, value=0.45, step=0.05
+            )
+            slit_separation = slit_columns[1].number_input(
+                "Slit separation",
+                min_value=0.2,
+                max_value=5.0,
+                value=1.2,
+                step=0.1,
+            )
+            automatic_projection = st.toggle("Automatic projection time", value=True)
+            explicit_time = st.number_input(
+                "Which-path projection time",
+                min_value=float(dt),
+                max_value=float(tf),
+                value=min(float(tf) * 0.55, float(tf) - float(dt)),
+                step=float(dt),
+                format="%.4f",
+                disabled=automatic_projection,
+            )
+            measurement_kind = "which_path"
+            measurement_time = None if automatic_projection else float(explicit_time)
 
         st.subheader("Boundary")
         absorbing_boundary = st.toggle("Absorbing edge", value=True)
@@ -152,7 +276,6 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
         )
         run_requested = st.button("Run simulation", type="primary", width="stretch")
 
-    experiment = "barrier_zeno" if is_barrier else "free_packet"
     return (
         DashboardParameters(
             name=experiment,
@@ -170,10 +293,13 @@ def _experiment_controls() -> tuple[DashboardParameters, bool]:
             barrier_height=float(barrier_height),
             barrier_x=float(barrier_x),
             barrier_width=float(barrier_width),
+            slit_width=float(slit_width),
+            slit_separation=float(slit_separation),
             measurement_kind=measurement_kind,
             measurement_interval=(
-                None if measurement_kind == "none" else float(measurement_interval)
+                float(measurement_interval) if measurement_kind == "zeno" else None
             ),
+            measurement_time=measurement_time,
             detector_buffer=float(detector_buffer),
             absorbing_boundary=absorbing_boundary,
             boundary_width=float(boundary_width),
@@ -187,12 +313,29 @@ def _show_experiment(dashboard_run: DashboardRun) -> None:
     result = dashboard_run.result
     metrics = experiment_summary(result)
     primary_metrics = st.columns(2)
-    primary_metrics[0].metric("Final norm", f"{float(metrics['final_norm']):.8f}")
-    primary_metrics[1].metric(
-        "Max norm drift", f"{float(metrics['max_norm_drift']):.2e}"
-    )
+    if result.config.experiment == "double_slit":
+        primary_metrics[0].metric(
+            "Final coherent norm", f"{float(metrics['final_norm']):.8f}"
+        )
+        primary_metrics[1].metric(
+            "Final which-path norm", f"{float(metrics['final_which_path_norm']):.8f}"
+        )
+    else:
+        primary_metrics[0].metric("Final norm", f"{float(metrics['final_norm']):.8f}")
+        primary_metrics[1].metric(
+            "Max norm drift", f"{float(metrics['max_norm_drift']):.2e}"
+        )
     probability_metrics = st.columns(2)
-    if result.config.experiment == "barrier_zeno":
+    if result.config.experiment == "double_slit":
+        probability_metrics[0].metric(
+            "Coherent contrast",
+            f"{float(metrics['coherent_interference_contrast']):.5f}",
+        )
+        probability_metrics[1].metric(
+            "Which-path contrast",
+            f"{float(metrics['which_path_interference_contrast']):.5f}",
+        )
+    elif result.config.experiment == "barrier_zeno":
         probability_metrics[0].metric(
             "No-click transmission",
             f"{float(metrics['final_unconditional_transmission_probability']):.5f}",
@@ -222,6 +365,15 @@ def _show_experiment(dashboard_run: DashboardRun) -> None:
     for column, figure in zip(field_columns, field_figures, strict=True):
         column.pyplot(figure, width="stretch")
         plt.close(figure)
+
+    if result.config.experiment == "double_slit":
+        comparison_columns = st.columns(2)
+        comparison_figures = plot_double_slit_panels(result, frame_index)
+        for column, figure in zip(
+            comparison_columns, comparison_figures, strict=True
+        ):
+            column.pyplot(figure, width="stretch")
+            plt.close(figure)
 
     diagnostic_columns = st.columns(2)
     diagnostic_figures = plot_diagnostic_panels(result)
@@ -253,6 +405,110 @@ def _show_experiment(dashboard_run: DashboardRun) -> None:
     download_columns[2].download_button(
         "Download report.html",
         report_path.read_bytes(),
+        file_name="report.html",
+        mime="text/html",
+        width="stretch",
+        on_click="ignore",
+    )
+
+
+def _zeno_sweep_workspace(parameters: DashboardParameters) -> None:
+    interval_options = [
+        value
+        for value in [0.0, 0.04, 0.06, 0.08, 0.12, 0.24]
+        if value == 0 or value <= parameters.tf
+    ]
+    default_intervals = [
+        value for value in [0.0, 0.06, 0.12] if value in interval_options
+    ]
+    if len(default_intervals) == 1 and len(interval_options) > 1:
+        default_intervals.append(interval_options[1])
+    control_columns = st.columns(2)
+    heights = control_columns[0].multiselect(
+        "Barrier heights",
+        options=[20.0, 40.0, 60.0, 80.0, 120.0],
+        default=[20.0, 40.0],
+        max_selections=5,
+        format_func=lambda value: f"{value:g}",
+    )
+    intervals = control_columns[1].multiselect(
+        "Measurement intervals",
+        options=interval_options,
+        default=default_intervals,
+        max_selections=5,
+        format_func=lambda value: "Unmeasured" if value == 0 else f"{value:g}",
+    )
+    variant_count = len(heights) * len(intervals)
+    st.caption(f"{variant_count} variants using the sidebar grid, packet, and solver settings")
+    if st.button(
+        "Run Zeno sweep",
+        type="primary",
+        disabled=(
+            variant_count == 0
+            or variant_count > 25
+            or 0.0 not in intervals
+            or not any(value > 0 for value in intervals)
+        ),
+    ):
+        out_dir = timestamped_output_dir(
+            ROOT / "reports" / "dashboard", "zeno-sweep"
+        )
+        base_parameters = replace(
+            parameters,
+            name="dashboard_zeno_sweep",
+            experiment="barrier_zeno",
+            measurement_kind="none",
+            measurement_interval=None,
+            measurement_time=None,
+        )
+        try:
+            with st.spinner("Running controlled Zeno variants and building reports..."):
+                st.session_state["dashboard_zeno_sweep"] = run_dashboard_zeno_sweep(
+                    base_parameters,
+                    tuple(float(value) for value in heights),
+                    tuple(float(value) for value in intervals),
+                    out_dir,
+                )
+        except (OSError, RuntimeError, ValueError) as exc:
+            st.error(str(exc))
+
+    sweep = st.session_state.get("dashboard_zeno_sweep")
+    if sweep is None:
+        st.info("Select a controlled parameter grid and run the sweep.")
+        return
+    _show_zeno_sweep(sweep)
+
+
+def _show_zeno_sweep(sweep: DashboardSweep) -> None:
+    plot_columns = st.columns(2)
+    plot_columns[0].image(sweep.outputs["comparison"], width="stretch")
+    plot_columns[1].image(sweep.outputs["heatmap"], width="stretch")
+    st.dataframe(
+        list(sweep.rows),
+        width="stretch",
+        hide_index=True,
+        column_config={
+            "barrier_height": st.column_config.NumberColumn(format="%.1f"),
+            "measurement_interval": st.column_config.NumberColumn(format="%.3f"),
+            "transmission": st.column_config.NumberColumn(format="%.3e"),
+            "detected": st.column_config.NumberColumn(format="%.3e"),
+            "survival": st.column_config.NumberColumn(format="%.3e"),
+            "absorbed": st.column_config.NumberColumn(format="%.3e"),
+        },
+    )
+    st.code(str(sweep.out_dir.relative_to(ROOT)))
+    download_columns = st.columns(2)
+    download_columns[0].download_button(
+        "Download comparison.csv",
+        sweep.outputs["csv"].read_bytes(),
+        file_name="comparison.csv",
+        mime="text/csv",
+        width="stretch",
+        on_click="ignore",
+    )
+    download_columns[1].download_button(
+        "Download sweep report",
+        sweep.outputs["html_report"].read_bytes(),
         file_name="report.html",
         mime="text/html",
         width="stretch",

--- a/src/quantum_dynamics_lab/dashboard.py
+++ b/src/quantum_dynamics_lab/dashboard.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -14,7 +14,7 @@ import matplotlib.pyplot as plt
 from matplotlib.figure import Figure
 import numpy as np
 
-from .artifacts import save_run
+from .artifacts import save_run, write_metrics
 from .config import (
     BoundaryConfig,
     ExperimentConfig,
@@ -26,7 +26,7 @@ from .config import (
     WavePacketConfig,
 )
 from .experiments import ExperimentResult, run_experiment
-from .render import render_run
+from .render import render_comparison, render_run
 from .validation import load_validation_config, run_validation
 
 
@@ -48,8 +48,11 @@ class DashboardParameters:
     barrier_height: float = 40.0
     barrier_x: float = 0.0
     barrier_width: float = 0.25
+    slit_width: float = 0.45
+    slit_separation: float = 1.2
     measurement_kind: str = "zeno"
     measurement_interval: float | None = 0.12
+    measurement_time: float | None = None
     detector_buffer: float = 0.25
     absorbing_boundary: bool = True
     boundary_width: float = 1.0
@@ -64,10 +67,24 @@ class DashboardRun:
     outputs: dict[str, Path]
 
 
+@dataclass(frozen=True)
+class DashboardSweep:
+    out_dir: Path
+    run_paths: tuple[Path, ...]
+    rows: tuple[dict[str, float], ...]
+    outputs: dict[str, Path]
+
+
 def build_experiment_config(parameters: DashboardParameters) -> ExperimentConfig:
     _validate_parameters(parameters)
     is_barrier = parameters.experiment == "barrier_zeno"
-    measurement_kind = parameters.measurement_kind if is_barrier else "none"
+    is_double_slit = parameters.experiment == "double_slit"
+    potential_kind = (
+        "double_slit" if is_double_slit else "barrier" if is_barrier else "free"
+    )
+    measurement_kind = (
+        "which_path" if is_double_slit else parameters.measurement_kind if is_barrier else "none"
+    )
     interval = parameters.measurement_interval if measurement_kind == "zeno" else None
     return ExperimentConfig(
         name=parameters.name,
@@ -79,10 +96,12 @@ def build_experiment_config(parameters: DashboardParameters) -> ExperimentConfig
             momentum=(parameters.momentum_x, parameters.momentum_y),
         ),
         potential=PotentialConfig(
-            kind="barrier" if is_barrier else "free",
-            height=parameters.barrier_height if is_barrier else 0.0,
+            kind=potential_kind,
+            height=parameters.barrier_height if is_barrier or is_double_slit else 0.0,
             barrier_x=parameters.barrier_x,
             barrier_width=parameters.barrier_width,
+            slit_width=parameters.slit_width,
+            slit_separation=parameters.slit_separation,
         ),
         solver=SolverConfig(
             dt=parameters.dt,
@@ -99,6 +118,7 @@ def build_experiment_config(parameters: DashboardParameters) -> ExperimentConfig
         measurement=MeasurementConfig(
             kind=measurement_kind,
             interval=interval,
+            time=parameters.measurement_time if is_double_slit else None,
             detector_buffer=parameters.detector_buffer if is_barrier else 0.0,
         ),
         output=OutputConfig(render_video=False),
@@ -113,6 +133,88 @@ def run_dashboard_experiment(
     run_path = save_run(result, out_dir)
     outputs = render_run(run_path, out_dir)
     return DashboardRun(result=result, run_path=run_path, outputs=outputs)
+
+
+def run_dashboard_zeno_sweep(
+    parameters: DashboardParameters,
+    heights: tuple[float, ...],
+    intervals: tuple[float, ...],
+    out_dir: str | Path,
+) -> DashboardSweep:
+    if not heights or not intervals:
+        raise ValueError("Zeno sweeps require at least one height and interval")
+    if len(heights) * len(intervals) > 25:
+        raise ValueError("interactive Zeno sweeps are limited to 25 variants")
+    if any(height < 0 for height in heights):
+        raise ValueError("barrier heights must not be negative")
+    if any(interval < 0 for interval in intervals):
+        raise ValueError("measurement intervals must not be negative")
+    if not any(interval == 0 for interval in intervals):
+        raise ValueError("Zeno sweeps must include an unmeasured interval of 0")
+    if not any(interval > 0 for interval in intervals):
+        raise ValueError("Zeno sweeps require at least one measured interval")
+
+    out_dir = Path(out_dir)
+    run_paths: list[Path] = []
+    run_dirs: list[Path] = []
+    rows: list[dict[str, float]] = []
+    variant_metrics: list[dict[str, object]] = []
+    for height in sorted(set(heights)):
+        for interval in sorted(set(intervals)):
+            measured = interval > 0
+            name = _sweep_variant_name(height, interval)
+            variant = replace(
+                parameters,
+                name=name,
+                experiment="barrier_zeno",
+                barrier_height=height,
+                measurement_kind="zeno" if measured else "none",
+                measurement_interval=interval if measured else None,
+                measurement_time=None,
+            )
+            result = run_experiment(build_experiment_config(variant))
+            run_dir = out_dir / "runs" / name
+            run_path = save_run(result, run_dir)
+            run_paths.append(run_path)
+            run_dirs.append(run_dir)
+            variant_metrics.append(result.metrics)
+            rows.append(
+                {
+                    "barrier_height": float(height),
+                    "measurement_interval": float(interval),
+                    "transmission": float(
+                        result.metrics["final_unconditional_transmission_probability"]
+                    ),
+                    "detected": float(result.metrics["final_detected_probability"]),
+                    "survival": float(result.metrics["final_survival_weight"]),
+                    "absorbed": float(result.metrics["final_absorbed_probability"]),
+                }
+            )
+
+    render_comparison(run_dirs, out_dir)
+    write_metrics(
+        out_dir / "metrics.json",
+        {"name": "dashboard_zeno_sweep", "variants": variant_metrics},
+    )
+    output_names = {
+        "comparison": "comparison.png",
+        "heatmap": "zeno_transmission_heatmap.png",
+        "csv": "comparison.csv",
+        "report": "report.md",
+        "html_report": "report.html",
+        "explorer": "explorer.html",
+    }
+    outputs = {
+        key: out_dir / filename
+        for key, filename in output_names.items()
+        if (out_dir / filename).exists()
+    }
+    return DashboardSweep(
+        out_dir=out_dir,
+        run_paths=tuple(run_paths),
+        rows=tuple(rows),
+        outputs=outputs,
+    )
 
 
 def run_dashboard_validation(
@@ -130,16 +232,38 @@ def timestamped_output_dir(
 
 
 def experiment_summary(result: ExperimentResult) -> dict[str, float]:
-    return {
+    summary = {
         "final_norm": float(result.metrics["final_norm"]),
         "max_norm_drift": float(np.max(np.abs(result.arrays["norm"] - 1.0))),
-        "final_unconditional_transmission_probability": float(
-            result.metrics["final_unconditional_transmission_probability"]
-        ),
-        "final_detected_probability": float(result.metrics["final_detected_probability"]),
-        "final_survival_weight": float(result.metrics["final_survival_weight"]),
-        "final_absorbed_probability": float(result.metrics["final_absorbed_probability"]),
     }
+    if result.config.experiment == "double_slit":
+        summary.update(
+            {
+                "final_which_path_norm": float(result.metrics["final_which_path_norm"]),
+                "coherent_interference_contrast": float(
+                    result.metrics["coherent_interference_contrast"]
+                ),
+                "which_path_interference_contrast": float(
+                    result.metrics["which_path_interference_contrast"]
+                ),
+            }
+        )
+    else:
+        summary.update(
+            {
+                "final_unconditional_transmission_probability": float(
+                    result.metrics["final_unconditional_transmission_probability"]
+                ),
+                "final_detected_probability": float(
+                    result.metrics["final_detected_probability"]
+                ),
+                "final_survival_weight": float(result.metrics["final_survival_weight"]),
+                "final_absorbed_probability": float(
+                    result.metrics["final_absorbed_probability"]
+                ),
+            }
+        )
+    return summary
 
 
 def plot_field_panels(result: ExperimentResult, frame_index: int) -> tuple[Figure, ...]:
@@ -156,7 +280,11 @@ def plot_field_panels(result: ExperimentResult, frame_index: int) -> tuple[Figur
     probability_image = probability_axis.imshow(
         probability, origin="lower", extent=extent, cmap="viridis", aspect="equal"
     )
-    probability_axis.set_title("Probability density")
+    probability_axis.set_title(
+        "Coherent probability density"
+        if result.config.experiment == "double_slit"
+        else "Probability density"
+    )
     probability_figure.colorbar(probability_image, ax=probability_axis, label="|psi|^2")
 
     phase_figure, phase_axis = plt.subplots(figsize=(4.4, 3.8))
@@ -202,6 +330,49 @@ def plot_field_panels(result: ExperimentResult, frame_index: int) -> tuple[Figur
     return figures
 
 
+def plot_double_slit_panels(
+    result: ExperimentResult, frame_index: int
+) -> tuple[Figure, ...]:
+    if result.config.experiment != "double_slit":
+        raise ValueError("double-slit panels require a double_slit result")
+    which_path_frames = result.arrays["which_path_probability_frames"]
+    if not 0 <= frame_index < len(which_path_frames):
+        raise IndexError("frame_index is outside the saved frame range")
+
+    density_figure, density_axis = plt.subplots(figsize=(5.4, 4.0))
+    density_image = density_axis.imshow(
+        which_path_frames[frame_index],
+        origin="lower",
+        extent=_extent(result),
+        cmap="cividis",
+        aspect="equal",
+    )
+    density_axis.set_title("Which-path probability density")
+    density_axis.set_xlabel("x")
+    density_axis.set_ylabel("y")
+    density_figure.colorbar(density_image, ax=density_axis, label="probability density")
+
+    profile_figure, profile_axis = plt.subplots(figsize=(5.4, 4.0))
+    profile_axis.plot(
+        result.grid.y,
+        result.arrays["coherent_screen_profile"],
+        label="coherent",
+    )
+    profile_axis.plot(
+        result.grid.y,
+        result.arrays["which_path_screen_profile"],
+        label="which-path",
+    )
+    profile_axis.set_title("Final screen profile")
+    profile_axis.set_xlabel("y")
+    profile_axis.set_ylabel("integrated probability")
+    profile_axis.grid(True, alpha=0.25)
+    profile_axis.legend(loc="best")
+    density_figure.tight_layout()
+    profile_figure.tight_layout()
+    return density_figure, profile_figure
+
+
 def plot_diagnostic_panels(result: ExperimentResult) -> tuple[Figure, ...]:
     arrays = result.arrays
     metric_times = arrays["metric_times"]
@@ -209,45 +380,79 @@ def plot_diagnostic_panels(result: ExperimentResult) -> tuple[Figure, ...]:
     probability_figure, probability_axis = plt.subplots(figsize=(5.4, 3.6))
 
     norm_drift = arrays["norm"] - 1.0
-    norm_axis.plot(
-        metric_times, norm_drift, color="#2563eb", label="conditional norm - 1"
-    )
+    if result.config.experiment == "double_slit":
+        norm_axis.plot(
+            metric_times, norm_drift, color="#2563eb", label="coherent norm - 1"
+        )
+        norm_axis.plot(
+            metric_times,
+            arrays["which_path_norm"] - 1.0,
+            color="#b45309",
+            label="which-path norm - 1",
+        )
+        norm_axis.set_title("Branch norm change with absorbing edges")
+    else:
+        norm_axis.plot(
+            metric_times, norm_drift, color="#2563eb", label="conditional norm - 1"
+        )
+        norm_axis.set_title("Norm drift")
     norm_axis.axhline(0.0, color="#6b7280", linewidth=0.8)
-    norm_axis.set_title("Norm drift")
     norm_axis.set_xlabel("time")
     norm_axis.set_ylabel("probability mass")
     norm_axis.grid(True, alpha=0.25)
+    norm_axis.legend(loc="best")
 
-    if result.config.experiment == "barrier_zeno":
+    if result.config.experiment == "double_slit":
+        labels = ("coherent", "which-path")
+        values = (
+            float(result.metrics["coherent_interference_contrast"]),
+            float(result.metrics["which_path_interference_contrast"]),
+        )
+        probability_axis.bar(labels, values, color=("#2563eb", "#b45309"))
+        probability_axis.set_title("Interference contrast")
+        probability_axis.set_ylabel("contrast")
+        probability_axis.set_ylim(0.0, max(1.0, max(values) * 1.15))
+        probability_axis.grid(True, axis="y", alpha=0.25)
+        for index, value in enumerate(values):
+            probability_axis.text(index, value, f"{value:.3f}", ha="center", va="bottom")
+    elif result.config.experiment == "barrier_zeno":
         series = (
             ("unconditional_transmission_probability", "no-click transmission"),
             ("detected_probability", "detector clicks"),
             ("survival_weight", "survival"),
             ("absorbed_probability", "absorbed"),
         )
+        for key, label in series:
+            probability_axis.plot(metric_times, arrays[key], label=label)
+        probability_axis.set_title("Probability accounting")
+        probability_axis.set_xlabel("time")
+        probability_axis.set_ylabel("probability")
+        probability_axis.set_ylim(-0.02, 1.02)
+        probability_axis.grid(True, alpha=0.25)
+        probability_axis.legend(loc="best")
     else:
         series = (
             ("survival_weight", "survival"),
             ("absorbed_probability", "absorbed"),
         )
-    for key, label in series:
-        probability_axis.plot(metric_times, arrays[key], label=label)
-    probability_axis.set_title("Probability accounting")
-    probability_axis.set_xlabel("time")
-    probability_axis.set_ylabel("probability")
-    probability_axis.set_ylim(-0.02, 1.02)
-    probability_axis.grid(True, alpha=0.25)
-    probability_axis.legend(loc="best")
+        for key, label in series:
+            probability_axis.plot(metric_times, arrays[key], label=label)
+        probability_axis.set_title("Probability accounting")
+        probability_axis.set_xlabel("time")
+        probability_axis.set_ylabel("probability")
+        probability_axis.set_ylim(-0.02, 1.02)
+        probability_axis.grid(True, alpha=0.25)
+        probability_axis.legend(loc="best")
     norm_figure.tight_layout()
     probability_figure.tight_layout()
     return norm_figure, probability_figure
 
 
 def _validate_parameters(parameters: DashboardParameters) -> None:
-    if parameters.experiment not in {"free_packet", "barrier_zeno"}:
-        raise ValueError("experiment must be free_packet or barrier_zeno")
-    if parameters.measurement_kind not in {"none", "zeno"}:
-        raise ValueError("measurement_kind must be none or zeno")
+    if parameters.experiment not in {"free_packet", "barrier_zeno", "double_slit"}:
+        raise ValueError("unsupported dashboard experiment")
+    if parameters.measurement_kind not in {"none", "zeno", "which_path"}:
+        raise ValueError("unsupported measurement kind")
     if parameters.grid_n < 16:
         raise ValueError("grid_n must be at least 16")
     if parameters.grid_length <= 0:
@@ -272,8 +477,10 @@ def _validate_parameters(parameters: DashboardParameters) -> None:
             raise ValueError("boundary_width must fit inside half the grid")
         if parameters.boundary_strength <= 0 or parameters.boundary_power <= 0:
             raise ValueError("absorbing boundary strength and power must be positive")
-    if parameters.experiment != "barrier_zeno":
+    if parameters.experiment == "free_packet":
         return
+    if parameters.barrier_height < 0:
+        raise ValueError("barrier_height must not be negative")
     if parameters.barrier_width <= 0:
         raise ValueError("barrier_width must be positive")
     barrier_left = parameters.barrier_x - parameters.barrier_width / 2.0
@@ -282,6 +489,19 @@ def _validate_parameters(parameters: DashboardParameters) -> None:
         raise ValueError("barrier_x must lie inside the grid")
     if barrier_left <= -half_length or barrier_right >= half_length:
         raise ValueError("barrier must fit entirely inside the grid")
+    if parameters.experiment == "double_slit":
+        if parameters.slit_width <= 0 or parameters.slit_separation <= 0:
+            raise ValueError("slit width and separation must be positive")
+        if parameters.slit_separation <= parameters.slit_width:
+            raise ValueError("slit separation must exceed slit width")
+        slit_outer_edge = (parameters.slit_separation + parameters.slit_width) / 2.0
+        if slit_outer_edge >= half_length:
+            raise ValueError("both slits must fit entirely inside the grid")
+        if parameters.measurement_time is not None and not (
+            0 < parameters.measurement_time < parameters.tf
+        ):
+            raise ValueError("which-path measurement time must lie between 0 and tf")
+        return
     if parameters.detector_buffer < 0:
         raise ValueError("detector_buffer must not be negative")
     detector_x = barrier_right + parameters.detector_buffer
@@ -297,6 +517,16 @@ def _validate_parameters(parameters: DashboardParameters) -> None:
             raise ValueError("Zeno measurements require a positive interval")
         if parameters.measurement_interval < parameters.dt:
             raise ValueError("measurement_interval must be at least dt")
+        if parameters.measurement_interval > parameters.tf:
+            raise ValueError("measurement_interval must not exceed tf")
+
+
+def _sweep_variant_name(height: float, interval: float) -> str:
+    height_label = f"{height:g}".replace("-", "m").replace(".", "p")
+    if interval == 0:
+        return f"h{height_label}_unmeasured"
+    interval_label = f"{interval:g}".replace("-", "m").replace(".", "p")
+    return f"h{height_label}_dt{interval_label}"
 
 
 def _extent(result: ExperimentResult) -> tuple[float, float, float, float]:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -11,8 +11,10 @@ from quantum_dynamics_lab.dashboard import (
     build_experiment_config,
     experiment_summary,
     plot_diagnostic_panels,
+    plot_double_slit_panels,
     plot_field_panels,
     run_dashboard_experiment,
+    run_dashboard_zeno_sweep,
 )
 
 
@@ -52,6 +54,37 @@ def test_dashboard_rejects_barrier_crossing_grid_edge() -> None:
         build_experiment_config(parameters)
 
 
+def test_dashboard_builds_double_slit_config() -> None:
+    config = build_experiment_config(
+        DashboardParameters(
+            name="double",
+            experiment="double_slit",
+            measurement_kind="which_path",
+            measurement_interval=None,
+            measurement_time=0.4,
+        )
+    )
+
+    assert config.potential.kind == "double_slit"
+    assert config.potential.slit_width == 0.45
+    assert config.measurement.kind == "which_path"
+    assert config.measurement.time == 0.4
+
+
+def test_dashboard_rejects_overlapping_slits() -> None:
+    parameters = replace(
+        DashboardParameters(),
+        experiment="double_slit",
+        measurement_kind="which_path",
+        measurement_interval=None,
+        slit_width=0.8,
+        slit_separation=0.7,
+    )
+
+    with pytest.raises(ValueError, match="separation must exceed"):
+        build_experiment_config(parameters)
+
+
 def test_dashboard_run_saves_artifacts_and_plots(tmp_path) -> None:
     parameters = DashboardParameters(
         name="dashboard_smoke",
@@ -85,6 +118,67 @@ def test_dashboard_run_saves_artifacts_and_plots(tmp_path) -> None:
     assert all(len(figure.axes) == 1 for figure in diagnostic_figures)
     for figure in (*field_figures, *diagnostic_figures):
         plt.close(figure)
+
+
+def test_dashboard_double_slit_run_builds_comparison_panels(tmp_path) -> None:
+    parameters = DashboardParameters(
+        name="double_slit_smoke",
+        experiment="double_slit",
+        grid_n=24,
+        grid_length=8.0,
+        center_x=-2.0,
+        sigma=0.5,
+        momentum_x=4.0,
+        dt=0.004,
+        tf=0.08,
+        frame_interval=0.04,
+        measurement_kind="which_path",
+        measurement_interval=None,
+        measurement_time=0.04,
+        boundary_width=1.0,
+    )
+
+    dashboard_run = run_dashboard_experiment(parameters, tmp_path / "double")
+    summary = experiment_summary(dashboard_run.result)
+    comparison_figures = plot_double_slit_panels(dashboard_run.result, 0)
+    diagnostic_figures = plot_diagnostic_panels(dashboard_run.result)
+
+    assert dashboard_run.run_path.exists()
+    assert "coherent_interference_contrast" in summary
+    assert "which_path_interference_contrast" in summary
+    assert len(comparison_figures) == 2
+    assert len(diagnostic_figures) == 2
+    for figure in (*comparison_figures, *diagnostic_figures):
+        plt.close(figure)
+
+
+def test_dashboard_zeno_sweep_writes_comparison_artifacts(tmp_path) -> None:
+    parameters = DashboardParameters(
+        name="sweep_smoke",
+        experiment="barrier_zeno",
+        grid_n=24,
+        grid_length=8.0,
+        center_x=-2.0,
+        sigma=0.5,
+        momentum_x=4.0,
+        dt=0.004,
+        tf=0.08,
+        frame_interval=0.04,
+        measurement_kind="none",
+        measurement_interval=None,
+        boundary_width=1.0,
+    )
+
+    sweep = run_dashboard_zeno_sweep(
+        parameters, (20.0,), (0.0, 0.04), tmp_path / "sweep"
+    )
+
+    assert len(sweep.run_paths) == 2
+    assert len(sweep.rows) == 2
+    assert sweep.outputs["comparison"].exists()
+    assert sweep.outputs["heatmap"].exists()
+    assert sweep.outputs["csv"].exists()
+    assert sweep.outputs["html_report"].exists()
 
 
 def test_streamlit_dashboard_starts_without_errors() -> None:


### PR DESCRIPTION
## Summary
- add a double-slit dashboard mode with slit geometry and which-path timing controls
- compare coherent and which-path densities, screen profiles, norms, and interference contrast
- add a bounded Zeno sweep workspace that saves NPZ variants and reuses the existing comparison reports
- give each experiment mode scientifically appropriate solver and packet defaults

## Scientific behavior
- validates wall and slit geometry against the domain
- validates explicit projection times and measurement intervals
- requires an unmeasured baseline plus at least one measured sweep interval
- distinguishes physical branch norm loss at absorbing edges from numerical norm drift

## Validation
- `uv run --extra ui pytest` (26 passed)
- `uv run python -m compileall -q src tests apps`
- `uvx ruff check src/quantum_dynamics_lab/dashboard.py apps/streamlit_dashboard.py tests/test_dashboard.py`
- live desktop/mobile checks for double-slit and Zeno sweep workflows

Closes #24