### PR TITLE
Complete M0 pivot foundation

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/implementation.md
+++ b/.github/ISSUE_TEMPLATE/implementation.md
@@ -1,0 +1,40 @@
+---
+name: Implementation task
+about: A scoped, testable engineering change
+title: ""
+labels: ""
+assignees: ""
+---
+
+## Outcome
+
+What observable capability will exist when this issue is complete?
+
+## Scope
+
+What code and behavior are included?
+
+## Acceptance Criteria
+
+- [ ] The outcome is implemented.
+- [ ] Focused tests cover the changed behavior.
+- [ ] The full regression suite passes.
+- [ ] Required examples, documentation, and artifacts are updated.
+
+## Validation and Evidence
+
+List the analytic result, parity check, gradient check, convergence study,
+benchmark, or experiment that will validate the change.
+
+## Out of Scope
+
+What does this issue intentionally not solve?
+
+## Dependencies
+
+Link blocking issues or applicable ADRs.
+
+## Expected Artifacts
+
+List configs, metrics, plots, reports, or benchmark outputs expected from the
+implementation.

--- a/.github/ISSUE_TEMPLATE/research-experiment.md
+++ b/.github/ISSUE_TEMPLATE/research-experiment.md
@@ -1,0 +1,55 @@
+---
+name: Research experiment
+about: A reproducible numerical question with declared evidence
+title: "[Experiment] "
+labels: "kind/research"
+assignees: ""
+---
+
+## Research Question
+
+What specific question will the experiment answer?
+
+## Hypothesis
+
+State the expected result before running the final experiment.
+
+## Fixed Configuration
+
+Identify committed configs, seeds, grids, and model versions.
+
+## Baselines
+
+List every comparison required for interpretation.
+
+## Optimization Perturbations
+
+List perturbations visible to the optimizer.
+
+## Held-Out Perturbations
+
+List perturbations reserved for evaluation.
+
+## Primary Metrics
+
+Define the metrics and how they are calculated.
+
+## Success Criteria
+
+- [ ] Declare quantitative or comparative criteria before final evaluation.
+
+## Permitted Claims
+
+What would passing the criteria establish? What would remain unsupported?
+
+## Required Artifacts
+
+- [ ] Resolved configuration and random seed
+- [ ] Environment and Git provenance
+- [ ] Optimization history
+- [ ] Baseline and held-out metrics
+- [ ] Generated report
+
+## Results
+
+Complete this section after the run; link the PR or workflow artifact.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+Closes #
+
+## Change
+
+Summarize the observable outcome and implementation approach.
+
+## Acceptance Criteria Satisfied
+
+- [ ] Linked issue criteria are complete.
+- [ ] Focused tests pass.
+- [ ] Full regression suite passes.
+- [ ] Relevant configs and documentation are updated.
+
+## Evidence
+
+- Tests:
+- Analytic or convergence validation:
+- Backend or gradient validation:
+- Generated report or artifact:
+
+## Scientific Interpretation
+
+State what the evidence establishes and what it does not establish.
+
+## Compatibility
+
+- [ ] Existing quantum workflows remain compatible, or changes are documented.
+- [ ] Config or artifact schema changes are documented.
+- [ ] Generated large files remain outside Git.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Project Operating Context
+
+## Mission
+
+This repository is being incrementally pivoted from a Quantum Zeno demonstration
+into a differentiable 2D wave inverse-design lab, with scalar photonics as the
+first practical application. The existing quantum workflows remain supported as
+legacy demonstrations and regression tests while a generic propagation core is
+built underneath them.
+
+## Read Before Making Changes
+
+1. Read `ROADMAP.md` for the current milestone, scope, and exit criteria.
+2. Read the accepted decisions in `docs/adr/` that apply to the work.
+3. Follow `CONTRIBUTING.md` for issue, branch, PR, validation, and evidence rules.
+
+GitHub issues are the source of truth for active work. `ROADMAP.md` records stable
+direction and milestone gates; it is not a daily task list.
+
+## Current Priority
+
+**M0 - Pivot foundation** is complete. The next behavioral work is the first
+part of **M1 - Forward optics v0.2**: extract a pure, backend-neutral
+propagation kernel and then make the maintained quantum solver delegate to it
+without changing recorded quantum v0.1 results. Do not add JAX, optimization,
+or more dashboard features ahead of that compatibility-preserving refactor.
+
+## Project Invariants
+
+- Do not remove or silently break the existing `quantum-lab` CLI, committed
+  quantum configs, or dashboard workflows during the pivot.
+- Do not present the current no-click Zeno trend or global min/max double-slit
+  contrast as independently validated research evidence.
+- Keep numerical propagation separate from configuration parsing, plotting,
+  artifact writing, dashboards, and experiment-specific branching.
+- Keep NumPy as the correctness reference. Add JAX as the differentiable path,
+  not as an implicit replacement for the reference implementation.
+- The first optics release is monochromatic, coherent, scalar free-space optics.
+  Do not imply vector-Maxwell or high-index integrated-photonics accuracy.
+- Generated `runs/` and `reports/` remain untracked. Commit inputs, small
+  reference metrics, and regeneration code instead of large outputs.
+
+## Required Evidence
+
+Match evidence to the change:
+
+- Refactors: legacy regression and backend-parity tests.
+- Propagation models: analytic checks, conservation/reversibility, and grid
+  convergence.
+- Differentiation: centered directional finite-difference gradient checks.
+- Optimization: deterministic objective-improvement tests plus saved history.
+- Research results: declared baselines, held-out perturbations, and a generated
+  model-transfer report.
+
+Run at least `uv run pytest` before handing off code changes. Add narrower
+commands and generated evidence when required by the issue acceptance criteria.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,92 @@
+# Contributing
+
+## Before Starting
+
+Read `AGENTS.md`, `ROADMAP.md`, and any relevant decision records under
+`docs/adr/`. Find or create a GitHub issue whose outcome and acceptance criteria
+match the proposed change.
+
+An issue is ready when it has:
+
+- one observable outcome;
+- explicit scope and non-goals;
+- measurable acceptance criteria;
+- the required validation or scientific evidence;
+- known dependencies;
+- expected generated artifacts, when applicable.
+
+## Branch and Pull-Request Workflow
+
+Use one primary issue per branch and pull request. Branches created by Codex use
+the form:
+
+```text
+codex/<issue-number>-<short-description>
+```
+
+Open a draft pull request early for work that spans more than one development
+session. Use `Closes #<issue>` in the PR body when merging should close the
+issue.
+
+## Definition of Done
+
+A change is done when:
+
+- the issue acceptance criteria are satisfied;
+- focused tests and the full regression suite pass;
+- relevant configs and user-facing documentation are updated;
+- required analytic, gradient, backend, convergence, or held-out evidence is
+  recorded;
+- generated artifacts include enough provenance to reproduce the result;
+- compatibility changes are explicit;
+- the PR states what its scientific evidence does and does not establish.
+
+## Validation Commands
+
+Minimum regression check:
+
+```bash
+uv sync --dev
+uv run pytest
+```
+
+Dashboard checks:
+
+```bash
+uv sync --dev --extra ui
+uv run --extra ui streamlit run apps/streamlit_dashboard.py
+```
+
+Additional commands belong in the issue acceptance criteria as optics,
+differentiation, optimization, and benchmark workflows are added.
+
+## Scientific and Numerical Changes
+
+Match evidence to the claim:
+
+- A refactor needs regression parity, not a new physical interpretation.
+- A propagation model needs analytic checks and convergence evidence.
+- A differentiable operator needs a directional finite-difference check.
+- An optimizer needs deterministic improvement and complete history.
+- A robustness claim needs held-out perturbations.
+- A transfer claim needs an independently implemented evaluation model.
+
+Do not weaken a tolerance solely to make a failing result pass. Explain and
+justify any tolerance change in the issue and PR.
+
+## Generated Artifacts
+
+`runs/` and `reports/` are intentionally ignored. Do not commit large NPZ files,
+videos, or transient optimizer checkpoints.
+
+Commit instead:
+
+- the complete input configuration;
+- deterministic seeds;
+- regeneration code;
+- small reference metrics or expected ranges;
+- concise documentation of the result.
+
+Optimization and research runs should record the Git commit, dirty-state flag,
+resolved config, dependency versions, backend/device, random seed, optimization
+history, and final plus held-out metrics.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # 2D-Quantum-Free-Particle
 
+> **Project direction:** this repository is being incrementally generalized into
+> a differentiable 2D wave inverse-design lab, with scalar photonics as the first
+> practical application. The existing quantum workflows remain supported during
+> the migration. See [ROADMAP.md](ROADMAP.md) for scope, milestones, and current
+> status.
+
 ## 2D Quantum Dynamics Lab
 
 This repository now includes a maintained Python package for reproducible
@@ -37,13 +43,15 @@ The dashboard provides parameter controls for free-packet, barrier/Zeno, and
 double-slit experiments, a saved-frame viewer for probability density and
 phase, norm and probability diagnostics, and access to the generated NPZ and
 report artifacts. Double-slit runs compare coherent and which-path densities,
-screen profiles, and interference contrast. The Zeno Sweep workspace runs a
-bounded grid of barrier heights and measurement intervals, including an
-unmeasured baseline, and generates the same CSV, heatmap, and HTML report used
-by the CLI comparison workflow. The validation workspace runs the same physics
-benchmarks as `quantum-lab validate` and displays their pass/fail results and
-convergence plots. Dashboard output is saved under `runs/dashboard/` and
-`reports/dashboard/`, which remain ignored by Git.
+screen profiles, and a global min/max screen-profile contrast. That contrast is
+a visualization and regression diagnostic; it has not been independently
+validated as a physical interference-visibility measurement. The Zeno Sweep
+workspace runs a bounded grid of barrier heights and measurement intervals,
+including an unmeasured baseline, and generates the same CSV, heatmap, and HTML
+report used by the CLI comparison workflow. The validation workspace runs the
+same numerical checks as `quantum-lab validate` and displays their pass/fail
+results and convergence plots. Dashboard output is saved under
+`runs/dashboard/` and `reports/dashboard/`, which remain ignored by Git.
 
 The new solver uses a NumPy Strang split-step Fourier method with periodic
 FFT boundaries, normalized Gaussian wave packets, configurable potentials, and
@@ -69,6 +77,11 @@ survival weight tracks the unconditional probability. Generated comparison
 reports include `comparison.csv`, `comparison.png`, `zeno_transmission_heatmap.png`,
 and `report.md`.
 
+This no-click projection is an algorithmic demonstration, not an independently
+validated open-system detector model. Its transmission trend is retained as a
+quantum v0.1 regression target; by itself it is not research evidence for the
+Quantum Zeno effect.
+
 Optional FFT backends can be selected in `[solver]` with `backend = "numpy"`,
 `"pyfftw"`, `"cupy"`, or `"auto"`. The default `auto` uses pyFFTW when it is
 installed and otherwise falls back to NumPy; CuPy and pyFFTW remain optional
@@ -77,30 +90,52 @@ dependencies. Install them with `uv sync --extra fftw` or
 
 The validation workflow writes `validation_metrics.json`,
 `validation_report.md`, `validation_report.html`, and `validation_summary.png`.
-It checks norm conservation, free Gaussian dispersion, barrier transmission
-trends, Zeno no-click transmission trends, and optional backend parity.
+It checks norm conservation, free Gaussian dispersion against the analytic
+width, qualitative barrier and no-click transmission trends, and optional
+backend parity. The norm and dispersion cases are numerical/analytic checks;
+the barrier and Zeno trend checks freeze current behavior without independently
+validating its physical interpretation. The separately reported double-slit
+contrast has the same regression-only status.
 
----
+## Legacy capstone implementation
+
+The material below describes the original C++/FFTW capstone implementation. It
+is retained as historical reference and is not the recommended interface for
+new runs.
 
 The mechanics of quantum free particles can be hard to study tangibly. With scientific computing, we are able to build a numerically stable simulation environment to test out models.
 
-This program numerically integrates the Schrodinger equation on finite complex scalar fields for simulating interactions of quantum particles under varied observation.
+This program numerically evolves the linear Schrodinger equation for a complex
+scalar wavefunction sampled on a finite, periodic grid.
 
-The goal: Can the Quantum-Zeno Effect a.k.a. the watch dog effect be modeled on an N-dimensional finite difference point lattice. The effects of repeated observation on a quantum wavefunction tend to resist the effects quantum tunneling.
+The original motivating question was whether repeated projection operations in
+a grid simulation could illustrate Zeno-like suppression of barrier
+transmission. The simulation is a demonstration model and does not establish
+the behavior of a physical measurement apparatus.
 
-This simulation is built with a 2D static potential field that the wave-function shares the same 2d xy space points.
+The static potential and wavefunction are sampled on the same two-dimensional
+Cartesian grid.
 
-The optimizations implemented with our work are geared toward removing the need to solve the non-linear term of the hamiltonian in traditional methods.  This frees the computational demand balance with accuracy (non-diverging data)
+Operator splitting applies the position-space potential phase and the
+momentum-space kinetic phase separately. The Hamiltonian implemented here is
+linear; there is no nonlinear Hamiltonian term being removed.
 
 ## About 2D Quantum Free Particle
 
-This version implements a second-order in time finite difference method known as the "split-step" Crank-Nicolson method. By calculating energy states using the hamiltonian in both position and momentum space, this program is able to achieve numerically stable integration, which is necessary for finite difference methods.
+The maintained Python package uses a second-order Strang split-step Fourier
+method: a half potential phase, a full spectral kinetic phase, and a second half
+potential phase. The legacy C++ loop shown below uses a first-order
+split-operator Fourier update with full potential and kinetic phases. Neither
+implementation is Crank-Nicolson, and the spatial Laplacian is handled
+spectrally rather than by finite differences.
 
-Each time-iteration, the program evolves the wave function in the position basis. Then we apply a Fourier transform to the wave function representation in position space to calculate the wave function representation in momentum space.
+Each legacy time step evolves the wavefunction in the position basis and then
+uses a Fourier transform to represent it in the momentum basis.
 
-Once the momentum space representation has been solved by FFTw we can evolve the non-linear term of the Hamiltonian in the momentum basis/phase-space.
+In the momentum basis, the FFTW implementation applies the kinetic-energy phase.
 
-The wavefunction in momentum space is finally reverse Fourier transformed back into position space in order to repeat this integration scheme at the next time step t + dt
+The wavefunction is finally inverse transformed to position space before the
+next time step.
 
 <p align="center">
 <img src="https://github.com/mauckc/2D-Quantum-Free-Particle/blob/master/visualization/larger-output-quantum.gif"/>
@@ -144,17 +179,9 @@ so that we have our momentum operator defined by:
 <img src="https://latex.codecogs.com/gif.latex?%5Chat%7Bp%7D%7E%3D%7E-i%5Chbar%20%5Cfrac%7B%5Cpartial%7D%7B%5Cpartial%20x%7D%7E."/>
 </p>
 
- This version implements a "split-step" Crank-Nicolson method
- We evolve our wave function in the position basis.
- Then we fourier transform the wavefunction to evolve it in the momentum basis
-
- Instead of integrating the following the standard position space representation of the equation:
-
- <p align="center">
-  <img src="https://latex.codecogs.com/gif.latex?%5Cbg_black%20i%20%28%5Cfrac%7Bd%5Cpsi%7D%7Bdx%7D%29%20%3D%20-%5Cfrac%7B1%7D%7B2%7D%20%28%5Cfrac%7Bd%5Cpsi%7D%7Bdx%7D%29%5E%7B2%7D%20&plus;%20U%28x%29%5Cpsi%28x%29"/>
-</p>
-
-This method is able to achieve a much higher level of accuracy by spliting our integration into two parts and relying on the flexibility of the FFTw algorithm to handle our computational complexity.
+The split-operator method alternates between bases so the potential operator is
+pointwise in position space and the kinetic operator is pointwise in momentum
+space. FFTW supplies the forward and inverse discrete Fourier transforms.
 
 <p align="center">
   <img src="https://github.com/mauckc/2D-Quantum-Free-Particle/blob/master/visualization/figures/img1.png" width=640 height=480 />

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,198 @@
+# Differentiable 2D Wave Inverse-Design Lab Roadmap
+
+Last updated: 2026-07-13
+
+## Direction
+
+The project will evolve from a maintained 2D quantum-dynamics demonstration into
+a reproducible wave-propagation and inverse-design laboratory. Scalar photonics
+is the first application because its FFT propagation operators closely match the
+existing split-step solver.
+
+The pivot is incremental. Existing quantum examples stay runnable while their
+numerical core is generalized and reused by a new optics layer.
+
+## First Product Boundary
+
+The first inverse-design release will support:
+
+- monochromatic coherent scalar fields `E(x, y; z)`;
+- NumPy reference propagation;
+- JAX-differentiable propagation;
+- Gaussian, Hermite-Gaussian, and arbitrary complex input fields;
+- Fresnel/paraxial and band-limited angular-spectrum propagation;
+- apertures, thin lenses, and phase-only masks;
+- mode-overlap, intensity-matching, and power-efficiency objectives;
+- bounded phase, smoothing, quantization, and robustness constraints;
+- reproducible configs, metrics, optimization histories, plots, and reports.
+
+The first release will not claim support for:
+
+- polarization or vector Maxwell fields;
+- reliable high-index-contrast integrated photonics;
+- nonlinear, broadband, or partially coherent propagation;
+- manufacturing-ready layout or mask export.
+
+## Delivery Flow
+
+```text
+M0 Pivot foundation
+  -> M1 Forward optics v0.2
+  -> M2 Differentiable solver v0.3
+  -> M3 Inverse-design MVP v0.4
+  -> M4 Robust flagship v1.0
+```
+
+## Milestones
+
+| Milestone | Status | Outcome |
+| --- | --- | --- |
+| M0 - Pivot foundation | Complete | Durable context, workflow templates, accepted decisions, corrected framing, and a frozen quantum v0.1 regression baseline |
+| M1 - Forward optics v0.2 | Planned | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
+| M2 - Differentiable solver v0.3 | Planned | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
+| M3 - Inverse-design MVP v0.4 | Planned | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
+| M4 - Robust flagship v1.0 | Planned | Robust multi-plane mode conversion, held-out perturbation results, cross-model validation, and the new CLI/dashboard identity |
+
+### M0 - Pivot Foundation
+
+Deliverables:
+
+- repository-owned roadmap and agent context;
+- architecture decision records;
+- issue and pull-request templates;
+- contribution, validation, and evidence rules;
+- corrected README language for the maintained algorithm and scientific claims;
+- small quantum regression fixtures covering free propagation, barrier runs,
+  and double-slit outputs;
+- a tagged or otherwise recorded v0.1 baseline after the above is reviewed.
+
+Exit gate:
+
+- all current CLI and dashboard workflows remain available;
+- the existing test suite passes;
+- future work can be understood from a fresh checkout without this conversation;
+- the first M1 issues have explicit acceptance criteria.
+
+### M1 - Forward Optics v0.2
+
+Deliverables:
+
+- a pure propagation API with no plotting, I/O, or experiment branching;
+- the existing quantum solver delegating to the new core;
+- optics-specific grids, units, sources, targets, and elements;
+- Fresnel/paraxial and band-limited angular-spectrum implementations;
+- analytic Gaussian-beam, thin-lens, reversibility, conservation, and
+  cross-model validation.
+
+Exit gate:
+
+- legacy quantum results remain within their recorded tolerances;
+- analytic optics errors and trusted numerical regimes are reported;
+- a CLI config can propagate a Gaussian beam through a lens or phase mask.
+
+### M2 - Differentiable Solver v0.3
+
+Deliverables:
+
+- optional JAX dependencies and array-native operators;
+- NumPy/JAX value parity;
+- scan-based propagation suitable for JIT compilation;
+- normalized mode-overlap and intensity objectives;
+- centered directional finite-difference gradient tests;
+- documented CPU and optional accelerator behavior.
+
+Exit gate:
+
+- required gradients meet declared relative-error tolerances;
+- a compiled optimization step runs in the supported CPU development setup;
+- GPU availability is not required for correctness or CI.
+
+### M3 - Inverse-Design MVP v0.4
+
+Deliverables:
+
+- bounded phase-mask parameterization;
+- smoothing, total-variation, and optional phase-quantization constraints;
+- Adam-based optimization with deterministic seeds, restart support, early
+  stopping, and best-design checkpoints;
+- optimization history, resolved config, environment, fields, metrics, and
+  report artifacts;
+- a small deterministic CI optimization that improves its objective.
+
+Exit gate:
+
+- optimization results can be reproduced from committed inputs;
+- the objective, constraints, and gradient evidence are visible in the report;
+- interruptions can resume from a checkpoint without changing the experiment.
+
+### M4 - Robust Flagship v1.0
+
+Flagship question:
+
+> Can a low-cost differentiable scalar propagator design a multi-plane
+> phase-only Gaussian-to-HG10 converter that remains useful under held-out
+> wavelength, alignment, phase-depth, and plane-spacing perturbations?
+
+Required comparisons:
+
+- no phase masks;
+- one optimized phase mask;
+- three masks optimized for nominal conditions;
+- three masks optimized over a robustness ensemble.
+
+Validation ladder:
+
+1. analytic optics checks;
+2. NumPy/JAX agreement;
+3. grid, padding, aperture, and step convergence;
+4. Fresnel-designed device evaluated with band-limited angular spectrum;
+5. an optional reduced-scale Maxwell/FDTD check only if computationally
+   practical.
+
+Exit gate:
+
+- optimization and held-out perturbation sets are distinct;
+- nominal and worst-case performance are reported against every baseline;
+- model-transfer loss and the trusted regime are explicit;
+- CLI, dashboard, and README lead with the wave inverse-design identity while
+  preserving `quantum-lab` compatibility.
+
+## Initial Epic Issues
+
+Create these as GitHub tracking issues and link child implementation issues from
+their checklists:
+
+1. `[Epic] Freeze and document the quantum v0.1 baseline`
+2. `[Epic] Extract the functional wave-propagation core`
+3. `[Epic] Add validated scalar-optics propagation`
+4. `[Epic] Add JAX differentiation and gradient validation`
+5. `[Epic] Implement the constrained inverse-design engine`
+6. `[Epic] Build the robust multi-plane mode converter`
+7. `[Epic] Validate transfer between propagation models`
+8. `[Epic] Reorganize the CLI, dashboard, and documentation`
+
+## Post-M0 Implementation Queue
+
+After M0 is merged, create and execute narrowly scoped issues in this order:
+
+1. Define the backend-neutral propagation interface.
+2. Refactor the current solver to delegate to the functional kernel.
+3. Add arbitrary complex input fields.
+4. Add optical grids and physical-unit configuration.
+5. Add Gaussian and Hermite-Gaussian sources.
+6. Implement and validate Fresnel propagation.
+7. Implement and validate band-limited angular-spectrum propagation.
+8. Add optional JAX execution and NumPy/JAX parity tests.
+
+## Tracking Rules
+
+- GitHub issues are the source of truth for active status and ownership.
+- Milestones group issues into releasable capabilities.
+- One issue should normally map to one branch and one pull request.
+- Architecture changes require an ADR or a superseding ADR.
+- Numerical or scientific issues must state their validation evidence before
+  implementation begins.
+- Large outputs remain ignored. Commit configs, regeneration code, and small
+  reference metrics; attach or upload full reports as workflow artifacts.
+- Update this roadmap only when direction, milestone scope, status, or exit gates
+  change.

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Committed numerical benchmark definitions and reference data."""

--- a/benchmarks/reference/README.md
+++ b/benchmarks/reference/README.md
@@ -1,0 +1,34 @@
+# Reference Metrics
+
+This directory holds small, committed numerical reference data used to detect
+regressions and document validated ranges.
+
+Reference files should contain metrics and tolerances, not large wave fields,
+videos, or generated reports. Each file must identify:
+
+- the generating config;
+- the metric definition;
+- the expected value or acceptable range;
+- the numerical tolerance and its justification;
+- the implementation or milestone that established the reference.
+
+Large run outputs belong under ignored `runs/` or `reports/` directories and may
+be published as CI artifacts or release assets.
+
+## Quantum v0.1 baseline
+
+`quantum_v0_1.json` freezes scalar metrics from the committed free-packet,
+barrier/Zeno, and double-slit example configurations. The reference generator
+forces the NumPy complex128 backend and includes both unmeasured and measured
+variants of the barrier configuration.
+
+Regenerate the file from the repository root with:
+
+```bash
+uv run python benchmarks/reference/generate_quantum_v0_1.py
+```
+
+The recorded tolerances allow only floating-point/FFT roundoff across supported
+platforms. They are regression tolerances, not uncertainty estimates and not
+evidence that the current Zeno or double-slit interpretation is physically
+validated.

--- a/benchmarks/reference/__init__.py
+++ b/benchmarks/reference/__init__.py
@@ -1,0 +1,1 @@
+"""Small reference metrics used by regression tests."""

--- a/benchmarks/reference/generate_quantum_v0_1.py
+++ b/benchmarks/reference/generate_quantum_v0_1.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+import argparse
+import json
+import subprocess
+
+import numpy as np
+
+from quantum_dynamics_lab.config import load_experiment_config
+from quantum_dynamics_lab.experiments import ExperimentResult, run_experiment
+from quantum_dynamics_lab.grid import integrate_probability
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+REFERENCE_PATH = Path(__file__).with_name("quantum_v0_1.json")
+
+CASE_SPECS = (
+    ("free_packet", "examples/free_packet.toml", None),
+    ("barrier_unmeasured", "examples/barrier_zeno.toml", "unmeasured"),
+    ("barrier_zeno", "examples/barrier_zeno.toml", None),
+    ("double_slit", "examples/double_slit.toml", None),
+)
+
+
+def collect_reference_metrics(repository_root: Path = REPOSITORY_ROOT) -> dict[str, Any]:
+    cases: dict[str, Any] = {}
+    for name, config_path, variant in CASE_SPECS:
+        config = load_experiment_config(repository_root / config_path)
+        config = replace(config, solver=replace(config.solver, backend="numpy"))
+        if variant == "unmeasured":
+            config = replace(
+                config,
+                name=name,
+                measurement=replace(
+                    config.measurement,
+                    kind="none",
+                    interval=None,
+                    time=None,
+                ),
+            )
+        result = run_experiment(config)
+        cases[name] = {
+            "config": config_path,
+            "variant": variant or "committed",
+            "metrics": _case_metrics(name, result),
+        }
+    return cases
+
+
+def build_reference_document(repository_root: Path = REPOSITORY_ROOT) -> dict[str, Any]:
+    return {
+        "backend": "numpy",
+        "baseline": "quantum-v0.1",
+        "cases": collect_reference_metrics(repository_root),
+        "milestone": "M0 - Pivot foundation",
+        "package_version": "0.1.0",
+        "schema_version": 1,
+        "scientific_interpretation": (
+            "These values freeze numerical behavior. They do not independently "
+            "validate the no-click Zeno or global min/max double-slit diagnostics."
+        ),
+        "source_commit": _source_commit(repository_root),
+        "tolerance": {
+            "absolute": 1e-10,
+            "relative": 1e-9,
+            "justification": (
+                "The cases use deterministic NumPy complex128 FFT propagation. "
+                "The tolerance permits platform-level floating-point roundoff "
+                "while remaining sensitive to solver and experiment changes."
+            ),
+        },
+    }
+
+
+def _case_metrics(name: str, result: ExperimentResult) -> dict[str, float]:
+    metrics = {
+        "final_norm": float(result.metrics["final_norm"]),
+        "max_norm_drift": float(np.max(np.abs(result.arrays["norm"] - 1.0))),
+    }
+    if name == "free_packet":
+        metrics.update(_free_packet_moments(result))
+    elif name.startswith("barrier_"):
+        for key in (
+            "final_absorbed_probability",
+            "final_detected_probability",
+            "final_survival_weight",
+            "final_transmission_probability",
+            "final_unconditional_transmission_probability",
+        ):
+            metrics[key] = float(result.metrics[key])
+        metrics["probability_balance"] = (
+            metrics["final_absorbed_probability"]
+            + metrics["final_detected_probability"]
+            + metrics["final_survival_weight"]
+        )
+    elif name == "double_slit":
+        for key in (
+            "coherent_interference_contrast",
+            "final_which_path_norm",
+            "which_path_interference_contrast",
+        ):
+            metrics[key] = float(result.metrics[key])
+        coherent_profile = result.arrays["coherent_screen_profile"]
+        which_path_profile = result.arrays["which_path_screen_profile"]
+        metrics["coherent_screen_profile_integral"] = float(
+            np.sum(coherent_profile) * result.grid.dy
+        )
+        metrics["which_path_screen_profile_integral"] = float(
+            np.sum(which_path_profile) * result.grid.dy
+        )
+    return metrics
+
+
+def _free_packet_moments(result: ExperimentResult) -> dict[str, float]:
+    probability = np.abs(result.arrays["psi_frames"][-1]) ** 2
+    mean_x = integrate_probability(probability * result.grid.X, result.grid)
+    mean_y = integrate_probability(probability * result.grid.Y, result.grid)
+    return {
+        "final_x_mean": mean_x,
+        "final_x_variance": integrate_probability(
+            probability * (result.grid.X - mean_x) ** 2, result.grid
+        ),
+        "final_y_mean": mean_y,
+        "final_y_variance": integrate_probability(
+            probability * (result.grid.Y - mean_y) ** 2, result.grid
+        ),
+    }
+
+
+def _source_commit(repository_root: Path) -> str:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate the quantum v0.1 metrics")
+    parser.add_argument("--output", type=Path, default=REFERENCE_PATH)
+    args = parser.parse_args()
+    document = build_reference_document()
+    args.output.write_text(
+        json.dumps(document, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/benchmarks/reference/quantum_v0_1.json
+++ b/benchmarks/reference/quantum_v0_1.json
@@ -1,0 +1,69 @@
+{
+  "backend": "numpy",
+  "baseline": "quantum-v0.1",
+  "cases": {
+    "barrier_unmeasured": {
+      "config": "examples/barrier_zeno.toml",
+      "metrics": {
+        "final_absorbed_probability": 0.045686116777975495,
+        "final_detected_probability": 0.0,
+        "final_norm": 1.0,
+        "final_survival_weight": 0.9543138832220236,
+        "final_transmission_probability": 0.28070090803770054,
+        "final_unconditional_transmission_probability": 0.2678767735734061,
+        "max_norm_drift": 6.661338147750939e-16,
+        "probability_balance": 0.9999999999999991
+      },
+      "variant": "unmeasured"
+    },
+    "barrier_zeno": {
+      "config": "examples/barrier_zeno.toml",
+      "metrics": {
+        "final_absorbed_probability": 0.02749633502890713,
+        "final_detected_probability": 0.34532918079639185,
+        "final_norm": 0.9999999999999998,
+        "final_survival_weight": 0.6271744841747007,
+        "final_transmission_probability": 0.004262215749605428,
+        "final_unconditional_transmission_probability": 0.0026731529642000694,
+        "max_norm_drift": 6.661338147750939e-16,
+        "probability_balance": 0.9999999999999997
+      },
+      "variant": "committed"
+    },
+    "double_slit": {
+      "config": "examples/double_slit.toml",
+      "metrics": {
+        "coherent_interference_contrast": 0.998964581837934,
+        "coherent_screen_profile_integral": 0.26118905072489196,
+        "final_norm": 1.0000000000002458,
+        "final_which_path_norm": 1.0000000000002538,
+        "max_norm_drift": 2.4580337765200966e-13,
+        "which_path_interference_contrast": 0.9836160725125962,
+        "which_path_screen_profile_integral": 0.25557573408749956
+      },
+      "variant": "committed"
+    },
+    "free_packet": {
+      "config": "examples/free_packet.toml",
+      "metrics": {
+        "final_norm": 1.0,
+        "final_x_mean": -1.399999998505502,
+        "final_x_variance": 0.28999999966069756,
+        "final_y_mean": -0.3000000000000019,
+        "final_y_variance": 0.2899999999999989,
+        "max_norm_drift": 6.661338147750939e-16
+      },
+      "variant": "committed"
+    }
+  },
+  "milestone": "M0 - Pivot foundation",
+  "package_version": "0.1.0",
+  "schema_version": 1,
+  "scientific_interpretation": "These values freeze numerical behavior. They do not independently validate the no-click Zeno or global min/max double-slit diagnostics.",
+  "source_commit": "dfd3d5b54ee3e0475bb48ee33439b3b1b6f3beff",
+  "tolerance": {
+    "absolute": 1e-10,
+    "justification": "The cases use deterministic NumPy complex128 FFT propagation. The tolerance permits platform-level floating-point roundoff while remaining sensitive to solver and experiment changes.",
+    "relative": 1e-09
+  }
+}

--- a/docs/adr/0001-preserve-quantum-compatibility.md
+++ b/docs/adr/0001-preserve-quantum-compatibility.md
@@ -1,0 +1,35 @@
+# ADR 0001: Preserve Quantum Compatibility During the Pivot
+
+Status: Accepted
+
+Date: 2026-07-13
+
+## Context
+
+The repository has a working Python package, CLI, dashboard, experiment configs,
+reports, and regression suite for 2D quantum demonstrations. Replacing them in a
+single rewrite would discard useful numerical coverage and make regressions hard
+to identify.
+
+## Decision
+
+The wave inverse-design functionality will be added incrementally. Existing
+quantum experiments will become adapters and legacy demonstrations over the new
+generic propagation core. The `quantum-lab` command and committed configs remain
+available through the initial optics and inverse-design releases.
+
+## Consequences
+
+- Core refactors require parity tests against recorded quantum results.
+- Public documentation must distinguish legacy demonstrations from the new
+  research direction.
+- Some compatibility code will remain temporarily after the new `wave-lab`
+  surface is introduced.
+- Package renaming is deferred until the new core and flagship experiment work.
+
+## Alternatives Considered
+
+- A clean-slate optics repository: rejected because it would strand tested code
+  and split maintenance.
+- Immediate package and CLI renaming: rejected because it would combine branding
+  churn with numerical refactoring.

--- a/docs/adr/0002-scalar-optics-mvp-scope.md
+++ b/docs/adr/0002-scalar-optics-mvp-scope.md
@@ -1,0 +1,37 @@
+# ADR 0002: Use Scalar Free-Space Optics for the MVP
+
+Status: Accepted
+
+Date: 2026-07-13
+
+## Context
+
+The maintained solver evolves a complex scalar field with FFT-based kinetic or
+diffraction operators and pointwise phase operators. Scalar free-space optics
+and thin phase elements reuse that structure directly. High-index integrated
+photonics would require vector fields, polarization, open ports, dispersive
+materials, and higher-fidelity Maxwell solvers.
+
+## Decision
+
+The first photonics application will be monochromatic, coherent, scalar
+free-space propagation through apertures, lenses, phase masks, and optional
+smooth index variations. The first flagship design will be a multi-plane
+phase-only Gaussian-to-HG10 mode converter.
+
+## Consequences
+
+- Fresnel/paraxial and band-limited angular-spectrum models are in scope.
+- Polarization, vector Maxwell fields, nonlinear optics, and manufacturing-ready
+  layout are out of scope for the MVP.
+- Reports must state the scalar approximation and its validated regime.
+- Integrated-photonics examples may be added later only with suitable validation.
+
+## Alternatives Considered
+
+- Semiconductor quantum transport: rejected for the first pivot because it
+  requires contacts, electrostatics, and NEGF or comparable transport models.
+- High-index silicon-photonic inverse design: deferred because it is not a
+  trustworthy application of the present scalar propagator.
+- Continuing with Quantum Zeno research: retained only as legacy demonstration
+  because credible extension would require open-system measurement models.

--- a/docs/adr/0003-numpy-reference-and-jax-differentiation.md
+++ b/docs/adr/0003-numpy-reference-and-jax-differentiation.md
@@ -1,0 +1,40 @@
+# ADR 0003: Keep NumPy as Reference and Add JAX for Differentiation
+
+Status: Accepted
+
+Date: 2026-07-13
+
+## Context
+
+The current solver and validation suite use NumPy, with optional FFT backends.
+Differentiation requires every traced array operation—not only the FFT—to remain
+inside the differentiable array system. Replacing the reference path outright
+would make it harder to separate modeling errors from autodiff or compilation
+errors.
+
+## Decision
+
+NumPy remains the correctness reference. JAX will be an optional differentiable
+execution path using pure functions and array-native operators. Correctness and
+CPU CI will not require a GPU. Accelerator execution is an optional performance
+path.
+
+## Consequences
+
+- The existing FFT-only backend abstraction is insufficient for the new core;
+  exponentials, reductions, casts, masks, and FFTs must all be backend-native.
+- NumPy/JAX parity and directional finite-difference checks are required.
+- 64-bit JAX execution is used for correctness comparisons where appropriate;
+  lower precision may be offered for production optimization.
+- CuPy and pyFFTW may continue serving forward simulations but do not
+  automatically become differentiable backends.
+
+## Alternatives Considered
+
+- JAX-only implementation: rejected because it would remove the independent
+  reference path.
+- PyTorch as the first differentiable backend: viable, but not selected because
+  JAX's NumPy-like functional transformations align more directly with the
+  planned propagator and robustness ensembles.
+- Hand-derived adjoints: deferred until profiling shows reverse-mode autodiff is
+  inadequate for the target problem sizes.

--- a/docs/adr/0004-propagation-model-validation-ladder.md
+++ b/docs/adr/0004-propagation-model-validation-ladder.md
@@ -1,0 +1,42 @@
+# ADR 0004: Validate with a Propagation-Model Ladder
+
+Status: Accepted
+
+Date: 2026-07-13
+
+## Context
+
+An internally consistent optimizer can exploit discretization and model errors.
+Successful optimization under one propagation function is not evidence that a
+physical device or even a second numerical model will reproduce the result.
+Full-wave Maxwell validation of millimetre-scale free-space systems may also be
+computationally impractical.
+
+## Decision
+
+Validation will progress through an explicit ladder:
+
+1. analytic Gaussian, lens, conservation, and reversibility checks;
+2. NumPy/JAX value agreement;
+3. grid, padding, aperture, and propagation-step convergence;
+4. Fresnel-designed devices evaluated with an independently implemented
+   band-limited angular-spectrum model;
+5. optional reduced-scale Maxwell/FDTD validation when practical.
+
+Held-out perturbations are required for robustness claims.
+
+## Consequences
+
+- Model-transfer loss becomes a primary reported metric.
+- The trusted numerical regime must be reported alongside successful results.
+- Maxwell validation is not a release blocker for the first scalar-optics MVP,
+  but scalar-model transfer is.
+- Research issues must declare their optimization and held-out evaluation sets
+  before final results are interpreted.
+
+## Alternatives Considered
+
+- Validate only against the optimizing model: rejected because it cannot reveal
+  model exploitation.
+- Require full Maxwell validation for every milestone: rejected as disproportionate
+  and potentially infeasible for the initial free-space scale.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,15 @@
+# Architecture Decision Records
+
+Architecture decision records capture durable choices whose reasoning should
+survive individual task threads and contributors.
+
+Each ADR contains a status, context, decision, consequences, and alternatives.
+Accepted ADRs are not rewritten to reverse a decision; add a new ADR that marks
+the older one as superseded.
+
+Current decisions:
+
+- `0001-preserve-quantum-compatibility.md`
+- `0002-scalar-optics-mvp-scope.md`
+- `0003-numpy-reference-and-jax-differentiation.md`
+- `0004-propagation-model-validation-ladder.md`

--- a/tests/test_quantum_v0_1_regression.py
+++ b/tests/test_quantum_v0_1_regression.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import sys
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+REFERENCE_PATH = REPOSITORY_ROOT / "benchmarks" / "reference" / "quantum_v0_1.json"
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.reference.generate_quantum_v0_1 import collect_reference_metrics
+
+
+def test_quantum_v0_1_reference_metrics() -> None:
+    reference = json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+
+    assert reference["baseline"] == "quantum-v0.1"
+    assert reference["backend"] == "numpy"
+    assert reference["schema_version"] == 1
+
+    actual_cases = collect_reference_metrics(REPOSITORY_ROOT)
+    expected_cases = reference["cases"]
+    assert actual_cases.keys() == expected_cases.keys()
+
+    tolerance = reference["tolerance"]
+    for case_name, expected_case in expected_cases.items():
+        actual_case = actual_cases[case_name]
+        assert actual_case["config"] == expected_case["config"]
+        assert actual_case["variant"] == expected_case["variant"]
+        assert actual_case["metrics"].keys() == expected_case["metrics"].keys()
+        for metric_name, expected_value in expected_case["metrics"].items():
+            assert actual_case["metrics"][metric_name] == pytest.approx(
+                expected_value,
+                abs=tolerance["absolute"],
+                rel=tolerance["relative"],
+            ), f"{case_name}.{metric_name} changed from the quantum v0.1 baseline"


### PR DESCRIPTION
Closes #26

## Change

Completes M0 by adding the repository-owned roadmap, operating context, contribution/evidence rules, accepted ADRs, and issue/PR templates. It corrects the README's solver terminology and scientific framing, then freezes the NumPy quantum v0.1 behavior in a small reproducible metrics fixture with regression coverage.

The maintained Python solver is now described as a second-order Strang split-step Fourier method, while the legacy C++ loop is identified as a first-order split-operator Fourier update rather than Crank-Nicolson or a finite-difference Laplacian. The README also states that the no-click Zeno trend and global min/max double-slit contrast are demonstration/regression diagnostics, not independently validated research evidence.

No propagation-core, optics, JAX, optimization, CLI, dashboard, config-schema, or artifact-schema implementation is included. Follow-up issues #27 and #28 define the first M1 interface and delegation tasks.

## Why

The pivot needed durable repository context and a numerical compatibility baseline before the solver is generalized. Without that baseline, the first M1 refactor could preserve norm while silently changing experiment outputs; without corrected framing, the README overstated both the numerical method and what the current diagnostics establish.

## Acceptance Criteria Satisfied

- [x] M0 roadmap, agent context, ADRs, contribution rules, and workflow templates are committed.
- [x] README solver terminology and scientific claims are corrected.
- [x] NumPy quantum v0.1 references cover free propagation, unmeasured and measured barrier cases, and double-slit outputs.
- [x] Focused regression tests enforce the recorded absolute/relative tolerances.
- [x] Existing quantum CLI/config/dashboard surfaces remain intact.
- [x] First M1 issues have explicit acceptance criteria and evidence requirements.
- [x] Focused and full regression suites pass.

## Evidence

- Focused baseline: `uv run pytest tests/test_quantum_v0_1_regression.py -q` — 1 passed.
- Required full suite: `uv run pytest` — 27 passed.
- UI-inclusive environment: `uv sync --dev --extra ui`; `uv run --extra ui pytest` — 27 passed.
- Whitespace/scope review: `git diff --cached --check` passed before commit.
- Reference artifact: `benchmarks/reference/quantum_v0_1.json`, generated by `benchmarks/reference/generate_quantum_v0_1.py`.

No new propagation model, differentiation, optimization, or convergence claim is introduced, so analytic, gradient, and model-transfer evidence are not applicable to this PR.

## Scientific Interpretation

The fixture establishes regression parity with the v0.1 NumPy implementation at the recorded tolerances. It does not independently validate the no-click projection as a physical open-system measurement model, the observed trend as evidence of the Quantum Zeno effect, or the global min/max double-slit metric as physical interference visibility.

## Compatibility

- [x] Existing `quantum-lab` workflows and committed configs remain available.
- [x] Config and run-artifact schemas are unchanged.
- [x] Dashboard behavior is unchanged and its tests pass with the UI extra.
- [x] Only small scalar metrics and regeneration code are committed; `runs/` and `reports/` remain untracked.