### PR TITLE
Define backend-neutral propagation interface

### DIFF
--- a/docs/propagation-interface.md
+++ b/docs/propagation-interface.md
@@ -1,0 +1,87 @@
+# Backend-Neutral Propagation Interface
+
+Issue #27 introduces a pure symmetric split-step interface in
+`quantum_dynamics_lab.propagation`. It does not yet change the maintained
+`SplitStepSolver`; that delegation belongs to issue #28 so parity can be
+measured against the pre-refactor implementation.
+
+## Responsibilities
+
+The caller owns:
+
+- the physical model, units, grid, and evolution step;
+- construction of position-space and spectral generator arrays;
+- boundary masks, normalization, diagnostics, and experiment branching;
+- configuration parsing, plotting, artifact writing, and dashboards.
+
+The propagation module owns:
+
+- backend-native exponentiation of the generator arrays;
+- the half-position, full-spectral, half-position composition;
+- validation that a field and its operators are matching 2D arrays.
+
+The explicit `PropagationBackend` owns array conversion, dtype/device policy,
+elementwise operations, and FFT execution. `NumPyPropagationBackend` is the
+complex128 correctness reference. Future JAX support must implement the same
+operations without converting traced arrays through NumPy.
+
+## Generator Convention
+
+For an evolution equation written as
+
+```text
+d(field) / ds = (G_position + G_spectral) field,
+```
+
+`prepare_split_step_operators` constructs
+
+```text
+exp(0.5 * ds * G_position)
+exp(      ds * G_spectral)
+exp(0.5 * ds * G_position)
+```
+
+The generators and `step_size` may use any consistent physical units. A
+negative step size prepares the inverse phases for reversibility checks.
+
+## NumPy Reference Example
+
+For the existing dimensionless quantum model, an adapter can prepare generators
+without passing configuration objects into the kernel:
+
+```python
+import numpy as np
+
+from quantum_dynamics_lab.propagation import (
+    NumPyPropagationBackend,
+    prepare_split_step_operators,
+    propagate_split_step,
+)
+
+backend = NumPyPropagationBackend()
+position_generator = -1j * potential / hbar
+spectral_generator = -1j * hbar * k_squared / (2.0 * mass)
+operators = prepare_split_step_operators(
+    position_generator,
+    spectral_generator,
+    dt,
+    backend=backend,
+)
+next_field = propagate_split_step(field, operators, backend=backend)
+```
+
+Boundary damping and absorbed-probability diagnostics are intentionally applied
+by the quantum adapter after `next_field` is returned.
+
+## Validation Contract
+
+`tests/test_propagation.py` records the interface-level evidence required before
+the maintained solver delegates to this module:
+
+- analytic phase evolution for a periodic plane wave;
+- norm conservation and forward/reverse reconstruction for a real potential;
+- decreasing free-Gaussian variance error under grid refinement;
+- complex-array parity with the untouched solver for free and static potentials;
+- matching 2D shape enforcement and non-mutation of input arrays.
+
+The committed quantum v0.1 metrics remain the end-to-end compatibility gate.

--- a/src/quantum_dynamics_lab/propagation.py
+++ b/src/quantum_dynamics_lab/propagation.py
@@ -1,0 +1,173 @@
+"""Pure, backend-neutral split-step propagation primitives.
+
+The caller owns physical units, grid construction, generator preparation,
+boundaries, normalization, diagnostics, and persistence. This module owns only
+the symmetric position/spectral composition and delegates every array operation
+to an explicit backend.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Generic, NamedTuple, Protocol, TypeVar
+
+import numpy as np
+from numpy.typing import NDArray
+
+
+ArrayT = TypeVar("ArrayT")
+ComplexArray = NDArray[np.complex128]
+Scalar = float | complex
+
+__all__ = [
+    "NumPyPropagationBackend",
+    "PropagationBackend",
+    "SplitStepOperators",
+    "prepare_split_step_operators",
+    "propagate_split_step",
+]
+
+
+class PropagationBackend(Protocol[ArrayT]):
+    """Array operations required by the split-step propagation kernel.
+
+    A backend owns array conversion, complex dtype/device policy, elementwise
+    operations, and FFT execution. Implementations must not convert through a
+    different array system inside these methods.
+    """
+
+    name: str
+
+    def asarray(self, values: object) -> ArrayT:
+        ...
+
+    def shape(self, values: ArrayT) -> tuple[int, ...]:
+        ...
+
+    def exp(self, values: ArrayT) -> ArrayT:
+        ...
+
+    def multiply(self, left: ArrayT, right: ArrayT | Scalar) -> ArrayT:
+        ...
+
+    def fft2(self, values: ArrayT) -> ArrayT:
+        ...
+
+    def ifft2(self, values: ArrayT) -> ArrayT:
+        ...
+
+
+@dataclass(frozen=True)
+class NumPyPropagationBackend:
+    """Complex128 NumPy correctness backend for propagation."""
+
+    name: str = "numpy"
+
+    def asarray(self, values: object) -> ComplexArray:
+        return np.asarray(values, dtype=np.complex128)
+
+    def shape(self, values: ComplexArray) -> tuple[int, ...]:
+        return values.shape
+
+    def exp(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(np.exp(values), dtype=np.complex128)
+
+    def multiply(
+        self, left: ComplexArray, right: ComplexArray | Scalar
+    ) -> ComplexArray:
+        return np.asarray(np.multiply(left, right), dtype=np.complex128)
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(np.fft.fft2(values), dtype=np.complex128)
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(np.fft.ifft2(values), dtype=np.complex128)
+
+
+class SplitStepOperators(NamedTuple, Generic[ArrayT]):
+    """Backend-native phase arrays for one symmetric split step."""
+
+    position_half_step: ArrayT
+    spectral_step: ArrayT
+
+
+def prepare_split_step_operators(
+    position_generator: object,
+    spectral_generator: object,
+    step_size: float,
+    *,
+    backend: PropagationBackend[ArrayT],
+) -> SplitStepOperators[ArrayT]:
+    """Exponentiate position and spectral generators for one step.
+
+    Generators are rates in the evolution coordinate: the position generator is
+    applied for half a step on either side of the full spectral-generator step.
+    Negative finite step sizes are supported for reversibility checks.
+    """
+
+    if not math.isfinite(step_size):
+        raise ValueError("step_size must be finite")
+    position = backend.asarray(position_generator)
+    spectral = backend.asarray(spectral_generator)
+    _validate_generator_shapes(position, spectral, backend)
+    return SplitStepOperators(
+        position_half_step=backend.exp(
+            backend.multiply(position, 0.5 * step_size)
+        ),
+        spectral_step=backend.exp(backend.multiply(spectral, step_size)),
+    )
+
+
+def propagate_split_step(
+    field: object,
+    operators: SplitStepOperators[ArrayT],
+    *,
+    backend: PropagationBackend[ArrayT],
+) -> ArrayT:
+    """Advance one two-dimensional field with a symmetric split step.
+
+    The function is pure: it returns a new backend array and does not mutate the
+    field or operators. The caller is responsible for applying boundaries and
+    computing diagnostics after this periodic FFT propagation step.
+    """
+
+    state = backend.asarray(field)
+    position = backend.asarray(operators.position_half_step)
+    spectral = backend.asarray(operators.spectral_step)
+    _validate_propagation_shapes(state, position, spectral, backend)
+
+    state = backend.multiply(position, state)
+    spectrum = backend.fft2(state)
+    state = backend.ifft2(backend.multiply(spectrum, spectral))
+    return backend.multiply(position, state)
+
+
+def _validate_generator_shapes(
+    position: ArrayT,
+    spectral: ArrayT,
+    backend: PropagationBackend[ArrayT],
+) -> None:
+    position_shape = backend.shape(position)
+    spectral_shape = backend.shape(spectral)
+    if len(position_shape) != 2 or len(spectral_shape) != 2:
+        raise ValueError("split-step generators must be two-dimensional")
+    if position_shape != spectral_shape:
+        raise ValueError("position and spectral generators must have matching shapes")
+
+
+def _validate_propagation_shapes(
+    field: ArrayT,
+    position: ArrayT,
+    spectral: ArrayT,
+    backend: PropagationBackend[ArrayT],
+) -> None:
+    shapes = (
+        backend.shape(field),
+        backend.shape(position),
+        backend.shape(spectral),
+    )
+    if any(len(shape) != 2 for shape in shapes):
+        raise ValueError("field and split-step operators must be two-dimensional")
+    if len(set(shapes)) != 1:
+        raise ValueError("field and split-step operators must have matching shapes")

--- a/tests/test_propagation.py
+++ b/tests/test_propagation.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.backends import NumPyBackend
+from quantum_dynamics_lab.config import GridConfig, SolverConfig, WavePacketConfig
+from quantum_dynamics_lab.grid import integrate_probability, make_grid, norm, normalize
+from quantum_dynamics_lab.propagation import (
+    NumPyPropagationBackend,
+    prepare_split_step_operators,
+    propagate_split_step,
+)
+from quantum_dynamics_lab.solver import SplitStepSolver
+from quantum_dynamics_lab.wavepackets import gaussian_packet
+
+
+def test_plane_wave_accumulates_expected_free_phase() -> None:
+    grid = make_grid(GridConfig(n=32, length=8.0))
+    mode = 2
+    wave_number = 2.0 * np.pi * mode / grid.length
+    field = normalize(
+        np.exp(1j * wave_number * grid.X).astype(np.complex128), grid
+    )
+    step_size = 0.01
+    backend = NumPyPropagationBackend()
+    operators = prepare_split_step_operators(
+        np.zeros_like(grid.X, dtype=np.complex128),
+        -0.5j * grid.k2,
+        step_size,
+        backend=backend,
+    )
+
+    evolved = propagate_split_step(field, operators, backend=backend)
+    expected = field * np.exp(-0.5j * wave_number**2 * step_size)
+
+    assert operators.position_half_step.dtype == np.complex128
+    assert operators.spectral_step.dtype == np.complex128
+    assert evolved.dtype == np.complex128
+    assert np.max(np.abs(evolved - expected)) < 1e-12
+    assert abs(norm(evolved, grid) - 1.0) < 1e-12
+
+
+def test_real_potential_step_is_conservative_and_reversible() -> None:
+    grid = make_grid(GridConfig(n=32, length=8.0))
+    rng = np.random.default_rng(20260713)
+    field = normalize(
+        (
+            rng.standard_normal((grid.n, grid.n))
+            + 1j * rng.standard_normal((grid.n, grid.n))
+        ).astype(np.complex128),
+        grid,
+    )
+    potential = 0.05 * (grid.X**2 + 0.5 * grid.Y**2)
+    position_generator = -1j * potential
+    spectral_generator = -0.5j * grid.k2
+    backend = NumPyPropagationBackend()
+    forward = prepare_split_step_operators(
+        position_generator,
+        spectral_generator,
+        0.004,
+        backend=backend,
+    )
+    reverse = prepare_split_step_operators(
+        position_generator,
+        spectral_generator,
+        -0.004,
+        backend=backend,
+    )
+
+    evolved = propagate_split_step(field, forward, backend=backend)
+    reconstructed = propagate_split_step(evolved, reverse, backend=backend)
+
+    assert abs(norm(evolved, grid) - norm(field, grid)) < 1e-12
+    assert np.max(np.abs(reconstructed - field)) < 1e-12
+
+
+def test_free_gaussian_variance_converges_with_grid_refinement() -> None:
+    sigma = 0.6
+    propagation_time = 0.4
+    expected_variance = sigma**2 + propagation_time**2 / (4.0 * sigma**2)
+    errors = []
+    backend = NumPyPropagationBackend()
+
+    for n in (16, 24):
+        grid = make_grid(GridConfig(n=n, length=12.0))
+        field = gaussian_packet(
+            WavePacketConfig(
+                center=(0.0, 0.0),
+                sigma=sigma,
+                momentum=(0.0, 0.0),
+            ),
+            grid,
+        )
+        operators = prepare_split_step_operators(
+            np.zeros_like(grid.X),
+            -0.5j * grid.k2,
+            propagation_time,
+            backend=backend,
+        )
+        evolved = propagate_split_step(field, operators, backend=backend)
+        probability = np.abs(evolved) ** 2
+        mean_x = integrate_probability(probability * grid.X, grid)
+        variance_x = integrate_probability(
+            probability * (grid.X - mean_x) ** 2,
+            grid,
+        )
+        errors.append(abs(variance_x - expected_variance))
+
+    assert errors[1] < errors[0] * 1e-4
+    assert errors[1] < 1e-9
+
+
+@pytest.mark.parametrize("potential_kind", ["free", "static"])
+def test_pure_kernel_matches_pre_refactor_solver(potential_kind: str) -> None:
+    grid = make_grid(GridConfig(n=32, length=8.0))
+    rng = np.random.default_rng(17)
+    field = normalize(
+        (
+            rng.standard_normal((grid.n, grid.n))
+            + 1j * rng.standard_normal((grid.n, grid.n))
+        ).astype(np.complex128),
+        grid,
+    )
+    if potential_kind == "free":
+        potential = np.zeros((grid.n, grid.n), dtype=np.float64)
+    else:
+        potential = 0.2 * np.cos(2.0 * np.pi * grid.X / grid.length) + 0.1 * np.sin(
+            2.0 * np.pi * grid.Y / grid.length
+        )
+    config = SolverConfig(
+        dt=0.007,
+        tf=0.007,
+        frame_interval=0.007,
+        hbar=1.3,
+        mass=0.8,
+        backend="numpy",
+    )
+    legacy = SplitStepSolver(
+        grid,
+        potential,
+        config,
+        backend=NumPyBackend(),
+    ).step(field)
+    backend = NumPyPropagationBackend()
+    operators = prepare_split_step_operators(
+        -1j * potential / config.hbar,
+        -1j * config.hbar * grid.k2 / (2.0 * config.mass),
+        config.dt,
+        backend=backend,
+    )
+
+    propagated = propagate_split_step(field, operators, backend=backend)
+
+    assert np.max(np.abs(propagated - legacy)) < 1e-12
+
+
+def test_inputs_must_be_matching_two_dimensional_arrays() -> None:
+    backend = NumPyPropagationBackend()
+    with pytest.raises(ValueError, match="generators must be two-dimensional"):
+        prepare_split_step_operators(
+            np.zeros(4),
+            np.zeros(4),
+            0.1,
+            backend=backend,
+        )
+    operators = prepare_split_step_operators(
+        np.zeros((4, 4)),
+        np.zeros((4, 4)),
+        0.1,
+        backend=backend,
+    )
+    with pytest.raises(ValueError, match="must have matching shapes"):
+        propagate_split_step(np.zeros((8, 8)), operators, backend=backend)
+
+
+def test_propagation_does_not_mutate_inputs() -> None:
+    backend = NumPyPropagationBackend()
+    field = np.arange(16, dtype=np.float64).reshape(4, 4).astype(np.complex128)
+    operators = prepare_split_step_operators(
+        -0.1j * np.ones((4, 4)),
+        -0.2j * np.ones((4, 4)),
+        0.05,
+        backend=backend,
+    )
+    field_before = field.copy()
+    position_before = operators.position_half_step.copy()
+    spectral_before = operators.spectral_step.copy()
+
+    result = propagate_split_step(field, operators, backend=backend)
+
+    np.testing.assert_array_equal(field, field_before)
+    np.testing.assert_array_equal(operators.position_half_step, position_before)
+    np.testing.assert_array_equal(operators.spectral_step, spectral_before)
+    assert not np.shares_memory(result, field)


### PR DESCRIPTION
Closes #27

## Change

Adds a pure symmetric split-step propagation API in `quantum_dynamics_lab.propagation` with an explicit array backend protocol and a NumPy complex128 correctness implementation. The kernel accepts fields and prepared numerical generator arrays; it has no dependency on configuration parsing, experiments, plotting, artifacts, or dashboards.

The maintained `SplitStepSolver` is deliberately unchanged in this PR so its pre-refactor step remains an independent parity reference for issue #27. Solver delegation is reserved for #28.

## Why

M1 needs a functional numerical seam before optics and JAX are added. Making array conversion, elementwise operations, exponentiation, and FFTs backend-owned prevents future differentiable paths from accidentally converting traced values through NumPy.

## Validation and evidence

- `uv run pytest` — 34 passed.
- Periodic plane-wave analytic phase error: below `1e-12`.
- Real-potential norm-conservation error: below `1e-12`.
- Forward/reverse reconstruction max error: below `1e-12`.
- Direct complex-array parity against the untouched solver for free and static potentials: below `1e-12`.
- Free-Gaussian variance error decreases under grid refinement and is below `1e-9` at the finer test grid.
- Quantum v0.1 references remain within their recorded tolerances.

## Compatibility

- Existing `quantum-lab` CLI/config/dashboard/artifact behavior is unchanged.
- NumPy remains the correctness reference.
- No JAX, optics propagation, optimization, or research claim is introduced.
- No generated `runs/` or `reports/` content is committed.

This is a stacked draft PR targeting the M0 branch from #29 because #27 depends on #26.