### PR TITLE
Delegate quantum solver to propagation kernel

### DIFF
--- a/src/quantum_dynamics_lab/solver.py
+++ b/src/quantum_dynamics_lab/solver.py
@@ -9,10 +9,47 @@ from numpy.typing import NDArray
 from .backends import FFTBackend, create_backend
 from .config import BoundaryConfig, SolverConfig
 from .grid import Grid, norm
+from .propagation import (
+    PropagationBackend,
+    SplitStepOperators,
+    prepare_split_step_operators,
+    propagate_split_step,
+)
 
 
 ComplexArray = NDArray[np.complex128]
 FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class _QuantumPropagationBackend:
+    """Adapt a legacy FFT backend to the array-native propagation protocol."""
+
+    fft_backend: FFTBackend
+
+    @property
+    def name(self) -> str:
+        return self.fft_backend.name
+
+    def asarray(self, values: object) -> ComplexArray:
+        return np.asarray(values, dtype=np.complex128)
+
+    def shape(self, values: ComplexArray) -> tuple[int, ...]:
+        return values.shape
+
+    def exp(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(np.exp(values), dtype=np.complex128)
+
+    def multiply(
+        self, left: ComplexArray, right: ComplexArray | float | complex
+    ) -> ComplexArray:
+        return np.asarray(np.multiply(left, right), dtype=np.complex128)
+
+    def fft2(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(self.fft_backend.fft2(values), dtype=np.complex128)
+
+    def ifft2(self, values: ComplexArray) -> ComplexArray:
+        return np.asarray(self.fft_backend.ifft2(values), dtype=np.complex128)
 
 
 @dataclass(frozen=True)
@@ -63,19 +100,28 @@ class SplitStepSolver:
     def backend_name(self) -> str:
         return self.fft_backend.name
 
+    @cached_property
+    def propagation_backend(self) -> PropagationBackend[ComplexArray]:
+        return _QuantumPropagationBackend(self.fft_backend)
+
+    @cached_property
+    def split_step_operators(self) -> SplitStepOperators[ComplexArray]:
+        return prepare_split_step_operators(
+            -1j * self.potential / self.config.hbar,
+            -1j * self.config.hbar * self.grid.k2 / (2.0 * self.config.mass),
+            self.config.dt,
+            backend=self.propagation_backend,
+        )
+
     def step(self, psi: ComplexArray) -> ComplexArray:
         return self.step_with_diagnostics(psi).psi
 
     def step_with_diagnostics(self, psi: ComplexArray) -> StepResult:
-        dt = self.config.dt
-        hbar = self.config.hbar
-        mass = self.config.mass
-        position_half = np.exp(-0.5j * self.potential * dt / hbar)
-        kinetic = np.exp(-1j * hbar * self.grid.k2 * dt / (2.0 * mass))
-        psi = position_half * psi
-        backend = self.fft_backend
-        psi = backend.ifft2(backend.fft2(psi) * kinetic)
-        psi = (position_half * psi).astype(np.complex128)
+        psi = propagate_split_step(
+            psi,
+            self.split_step_operators,
+            backend=self.propagation_backend,
+        )
         before_absorber = norm(psi, self.grid)
         psi = self.absorber_mask * psi
         absorbed = max(0.0, before_absorber - norm(psi, self.grid))

--- a/tests/test_solver_experiments_cli.py
+++ b/tests/test_solver_experiments_cli.py
@@ -21,6 +21,7 @@ from quantum_dynamics_lab.experiments import run_experiment
 from quantum_dynamics_lab.grid import make_grid, norm, normalize
 from quantum_dynamics_lab.render import render_run
 from quantum_dynamics_lab.solver import SplitStepSolver
+from quantum_dynamics_lab.wavepackets import gaussian_packet
 
 
 def test_free_packet_norm_drift_stays_small() -> None:
@@ -64,6 +65,28 @@ def test_fft_backend_selection_and_missing_optional_errors() -> None:
             create_backend("cupy")
     else:
         assert create_backend("cupy").name == "cupy"
+
+
+def test_solver_delegates_to_pure_propagation_kernel(monkeypatch: pytest.MonkeyPatch) -> None:
+    import quantum_dynamics_lab.solver as solver_module
+
+    grid = make_grid(GridConfig(n=16, length=8.0))
+    solver_config = SolverConfig(dt=0.01, tf=0.01, frame_interval=0.01)
+    solver = SplitStepSolver(grid, np.zeros((grid.n, grid.n)), solver_config)
+    psi = gaussian_packet(WavePacketConfig(), grid)
+    calls: list[str] = []
+    original = solver_module.propagate_split_step
+
+    def recording_kernel(field, operators, *, backend):
+        calls.append(backend.name)
+        return original(field, operators, backend=backend)
+
+    monkeypatch.setattr(solver_module, "propagate_split_step", recording_kernel)
+
+    result = solver.step_with_diagnostics(psi)
+
+    assert calls == [solver.backend_name]
+    assert result.psi.dtype == np.complex128
 
 
 def test_barrier_zeno_fast_measurement_reduces_detection() -> None:


### PR DESCRIPTION
Closes #28

## Change

Makes `SplitStepSolver.step` and `step_with_diagnostics` delegate their numerical split-step composition to the pure propagation kernel introduced by #27. A private adapter preserves the existing NumPy/pyFFTW/CuPy FFT backend contract while supplying the array-native operations required by the kernel.

Prepared operators are cached per immutable solver instance. Absorbing-boundary application and absorbed-probability accounting remain in the quantum adapter after periodic propagation.

## Why

This removes duplicated propagation math from the maintained quantum solver and establishes the compatibility-preserving adapter required before optics models are added.

## Validation and evidence

- `uv run pytest` — 35 passed.
- Focused solver, quantum-v0.1, and validation suite — 15 passed.
- `uv run --extra ui pytest tests/test_dashboard.py -q` — 9 passed.
- Delegation is asserted with a recording kernel test.
- Every metric in `benchmarks/reference/quantum_v0_1.json` remains within its recorded tolerances.
- Existing backend-parity validation remains green; unavailable optional backends continue to skip explicitly.

## Compatibility

- `quantum-lab` commands, committed configs, artifacts, and dashboard behavior are unchanged.
- Boundary damping and conditional experiment behavior are unchanged.
- NumPy remains the correctness reference.
- This refactor establishes numerical parity only; it does not add or validate a new scientific interpretation.

This is a stacked draft PR targeting the #27 branch.