### PR TITLE
Add scalar-optics foundation

### DIFF
--- a/docs/scalar-optics-conventions.md
+++ b/docs/scalar-optics-conventions.md
@@ -1,0 +1,31 @@
+# Scalar-Optics Conventions
+
+The optics layer models a monochromatic, coherent scalar field sampled on a
+transverse periodic grid. It is a free-space/paraxial laboratory model, not a
+vector-Maxwell or high-index integrated-photonics solver.
+
+Lengths, wavelength, waist, and focal length may use any one consistent unit;
+the committed examples use SI units. Arrays are indexed as `(y, x)`. Spatial
+frequencies are cycles per unit length in NumPy FFT order. Integrated power is
+
+```text
+sum(abs(E)**2) * dx * dy.
+```
+
+Gaussian and Hermite-Gaussian constructors return numerically normalized
+complex128 fields. Hermite-Gaussian orders use the conventional `(x, y)` order,
+so HG10 is `(1, 0)`. The Gaussian `waist` is the field-amplitude 1/e radius.
+Arbitrary fields are copied without implicit normalization so measured or
+externally generated amplitudes retain their meaning.
+
+For forward propagation with carrier convention `exp(+i k z)`, a thin lens has
+transmission
+
+```text
+exp(-i * k * ((x-x0)^2 + (y-y0)^2) / (2*f)).
+```
+
+Apertures are passive binary transmissions. Phase-only masks must lie inside
+their declared phase bounds and have unit magnitude. Thin-element application
+rejects gain, does not mutate its inputs, and remains separate from propagation,
+configuration, plotting, artifact writing, experiments, and dashboards.

--- a/src/quantum_dynamics_lab/optics.py
+++ b/src/quantum_dynamics_lab/optics.py
@@ -1,0 +1,320 @@
+"""Pure NumPy foundations for coherent monochromatic scalar optics."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+ComplexArray = NDArray[np.complex128]
+FloatArray = NDArray[np.float64]
+
+__all__ = [
+    "OpticalGrid",
+    "apply_thin_element",
+    "as_complex_field",
+    "circular_aperture",
+    "field_power",
+    "gaussian_mode",
+    "hermite_gaussian_mode",
+    "make_optical_grid",
+    "normalize_field",
+    "phase_only_mask",
+    "rectangular_aperture",
+    "thin_lens",
+]
+
+
+@dataclass(frozen=True)
+class OpticalGrid:
+    """Sampled transverse plane for a scalar field.
+
+    ``shape`` and ``extent`` are ordered as ``(y, x)``. Spatial-frequency
+    arrays use NumPy FFT ordering so they can multiply ``fft2`` output directly.
+    """
+
+    shape: tuple[int, int]
+    extent: tuple[float, float]
+    wavelength: float
+    dy: float
+    dx: float
+    y: FloatArray
+    x: FloatArray
+    Y: FloatArray
+    X: FloatArray
+    fy: FloatArray
+    fx: FloatArray
+    FY: FloatArray
+    FX: FloatArray
+
+    @property
+    def wave_number(self) -> float:
+        return 2.0 * math.pi / self.wavelength
+
+    @property
+    def sample_area(self) -> float:
+        return self.dy * self.dx
+
+
+def make_optical_grid(
+    shape: int | tuple[int, int],
+    extent: float | tuple[float, float],
+    wavelength: float,
+) -> OpticalGrid:
+    """Construct a centered periodic grid using consistent physical units."""
+
+    ny, nx = _pair_of_ints(shape, "shape")
+    ly, lx = _pair_of_positive_floats(extent, "extent")
+    if not math.isfinite(wavelength) or wavelength <= 0.0:
+        raise ValueError("wavelength must be finite and positive")
+
+    dy = ly / ny
+    dx = lx / nx
+    y = (np.arange(ny, dtype=np.float64) - ny // 2) * dy
+    x = (np.arange(nx, dtype=np.float64) - nx // 2) * dx
+    fy = np.fft.fftfreq(ny, d=dy).astype(np.float64)
+    fx = np.fft.fftfreq(nx, d=dx).astype(np.float64)
+    X, Y = np.meshgrid(x, y, indexing="xy")
+    FX, FY = np.meshgrid(fx, fy, indexing="xy")
+    arrays = tuple(_read_only(values) for values in (y, x, Y, X, fy, fx, FY, FX))
+    return OpticalGrid(
+        shape=(ny, nx),
+        extent=(ly, lx),
+        wavelength=float(wavelength),
+        dy=dy,
+        dx=dx,
+        y=arrays[0],
+        x=arrays[1],
+        Y=arrays[2],
+        X=arrays[3],
+        fy=arrays[4],
+        fx=arrays[5],
+        FY=arrays[6],
+        FX=arrays[7],
+    )
+
+
+def as_complex_field(values: ArrayLike, grid: OpticalGrid) -> ComplexArray:
+    """Copy an arbitrary complex field without changing its amplitude."""
+
+    field = np.array(values, dtype=np.complex128, copy=True)
+    _validate_shape(field, grid, "field")
+    if not np.all(np.isfinite(field)):
+        raise ValueError("field must contain only finite values")
+    return field
+
+
+def field_power(field: ArrayLike, grid: OpticalGrid) -> float:
+    """Integrate scalar-field power over the sampled transverse plane."""
+
+    values = np.asarray(field)
+    _validate_shape(values, grid, "field")
+    return float(np.sum(np.abs(values) ** 2, dtype=np.float64) * grid.sample_area)
+
+
+def normalize_field(field: ArrayLike, grid: OpticalGrid) -> ComplexArray:
+    """Return a unit-power complex128 copy of ``field``."""
+
+    values = as_complex_field(field, grid)
+    power = field_power(values, grid)
+    if not math.isfinite(power) or power <= 0.0:
+        raise ValueError("field power must be finite and positive")
+    return np.asarray(values / math.sqrt(power), dtype=np.complex128)
+
+
+def gaussian_mode(
+    grid: OpticalGrid,
+    waist: float,
+    *,
+    center: tuple[float, float] = (0.0, 0.0),
+) -> ComplexArray:
+    """Return a unit-power waist-plane Gaussian field.
+
+    ``waist`` is the field-amplitude 1/e radius and ``center`` is ``(y, x)``.
+    """
+
+    waist = _positive_finite(waist, "waist")
+    cy, cx = _finite_pair(center, "center")
+    radius_squared = (grid.X - cx) ** 2 + (grid.Y - cy) ** 2
+    return normalize_field(np.exp(-radius_squared / waist**2), grid)
+
+
+def hermite_gaussian_mode(
+    grid: OpticalGrid,
+    order: tuple[int, int],
+    waist: float,
+    *,
+    center: tuple[float, float] = (0.0, 0.0),
+) -> ComplexArray:
+    """Return a unit-power waist-plane Hermite-Gaussian ``(x, y)`` mode."""
+
+    mx, my = _pair_of_nonnegative_ints(order, "order")
+    waist = _positive_finite(waist, "waist")
+    cy, cx = _finite_pair(center, "center")
+    scaled_y = math.sqrt(2.0) * (grid.Y - cy) / waist
+    scaled_x = math.sqrt(2.0) * (grid.X - cx) / waist
+    coefficients_y = np.zeros(my + 1, dtype=np.float64)
+    coefficients_x = np.zeros(mx + 1, dtype=np.float64)
+    coefficients_y[my] = 1.0
+    coefficients_x[mx] = 1.0
+    envelope = np.exp(
+        -((grid.X - cx) ** 2 + (grid.Y - cy) ** 2) / waist**2
+    )
+    field = (
+        np.polynomial.hermite.hermval(scaled_y, coefficients_y)
+        * np.polynomial.hermite.hermval(scaled_x, coefficients_x)
+        * envelope
+    )
+    return normalize_field(field, grid)
+
+
+def circular_aperture(
+    grid: OpticalGrid,
+    radius: float,
+    *,
+    center: tuple[float, float] = (0.0, 0.0),
+) -> FloatArray:
+    """Return the binary transmission of a circular aperture."""
+
+    radius = _positive_finite(radius, "radius")
+    cy, cx = _finite_pair(center, "center")
+    return np.asarray(
+        (grid.X - cx) ** 2 + (grid.Y - cy) ** 2 <= radius**2,
+        dtype=np.float64,
+    )
+
+
+def rectangular_aperture(
+    grid: OpticalGrid,
+    size: float | tuple[float, float],
+    *,
+    center: tuple[float, float] = (0.0, 0.0),
+) -> FloatArray:
+    """Return the binary transmission of a centered ``(height, width)`` aperture."""
+
+    height, width = _pair_of_positive_floats(size, "size")
+    cy, cx = _finite_pair(center, "center")
+    return np.asarray(
+        (np.abs(grid.Y - cy) <= height / 2.0)
+        & (np.abs(grid.X - cx) <= width / 2.0),
+        dtype=np.float64,
+    )
+
+
+def thin_lens(
+    grid: OpticalGrid,
+    focal_length: float,
+    *,
+    center: tuple[float, float] = (0.0, 0.0),
+) -> ComplexArray:
+    """Return paraxial thin-lens transmission for the exp(+i k z) convention."""
+
+    if not math.isfinite(focal_length) or focal_length == 0.0:
+        raise ValueError("focal_length must be finite and nonzero")
+    cy, cx = _finite_pair(center, "center")
+    phase = -grid.wave_number * (
+        (grid.X - cx) ** 2 + (grid.Y - cy) ** 2
+    ) / (2.0 * focal_length)
+    return np.asarray(np.exp(1j * phase), dtype=np.complex128)
+
+
+def phase_only_mask(
+    phase: ArrayLike,
+    grid: OpticalGrid,
+    *,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+) -> ComplexArray:
+    """Convert a finite, bounded phase array to unit-magnitude transmission."""
+
+    values = np.asarray(phase, dtype=np.float64)
+    _validate_shape(values, grid, "phase")
+    lower, upper = _finite_pair(bounds, "bounds")
+    if lower >= upper:
+        raise ValueError("phase bounds must be strictly increasing")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("phase must contain only finite values")
+    tolerance = 16.0 * np.finfo(np.float64).eps
+    if np.any(values < lower - tolerance) or np.any(values > upper + tolerance):
+        raise ValueError("phase values must lie within bounds")
+    return np.asarray(np.exp(1j * values), dtype=np.complex128)
+
+
+def apply_thin_element(
+    field: ArrayLike,
+    transmission: ArrayLike,
+    grid: OpticalGrid,
+) -> ComplexArray:
+    """Apply a sampled thin element without mutating either input."""
+
+    values = as_complex_field(field, grid)
+    element = np.asarray(transmission, dtype=np.complex128)
+    _validate_shape(element, grid, "transmission")
+    if not np.all(np.isfinite(element)):
+        raise ValueError("transmission must contain only finite values")
+    if np.any(np.abs(element) > 1.0 + 16.0 * np.finfo(np.float64).eps):
+        raise ValueError("passive transmission magnitude cannot exceed one")
+    return np.asarray(values * element, dtype=np.complex128)
+
+
+def _pair_of_ints(values: int | tuple[int, int], name: str) -> tuple[int, int]:
+    pair = (values, values) if isinstance(values, int) else values
+    if len(pair) != 2 or any(
+        isinstance(value, bool) or not isinstance(value, int) for value in pair
+    ):
+        raise ValueError(f"{name} must contain two integers")
+    if any(value < 2 for value in pair):
+        raise ValueError(f"{name} entries must be at least two")
+    return pair
+
+
+def _pair_of_nonnegative_ints(
+    values: tuple[int, int], name: str
+) -> tuple[int, int]:
+    if len(values) != 2 or any(
+        isinstance(value, bool) or not isinstance(value, int) for value in values
+    ):
+        raise ValueError(f"{name} must contain two integers")
+    if any(value < 0 for value in values):
+        raise ValueError(f"{name} entries must be nonnegative")
+    return values
+
+
+def _pair_of_positive_floats(
+    values: float | tuple[float, float], name: str
+) -> tuple[float, float]:
+    pair = (values, values) if isinstance(values, (int, float)) else values
+    if len(pair) != 2:
+        raise ValueError(f"{name} must contain two values")
+    converted = (float(pair[0]), float(pair[1]))
+    if any(not math.isfinite(value) or value <= 0.0 for value in converted):
+        raise ValueError(f"{name} entries must be finite and positive")
+    return converted
+
+
+def _finite_pair(values: tuple[float, float], name: str) -> tuple[float, float]:
+    if len(values) != 2:
+        raise ValueError(f"{name} must contain two values")
+    converted = (float(values[0]), float(values[1]))
+    if any(not math.isfinite(value) for value in converted):
+        raise ValueError(f"{name} entries must be finite")
+    return converted
+
+
+def _positive_finite(value: float, name: str) -> float:
+    converted = float(value)
+    if not math.isfinite(converted) or converted <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return converted
+
+
+def _validate_shape(values: NDArray[np.generic], grid: OpticalGrid, name: str) -> None:
+    if values.ndim != 2 or values.shape != grid.shape:
+        raise ValueError(f"{name} must have shape {grid.shape}")
+
+
+def _read_only(values: FloatArray) -> FloatArray:
+    values.setflags(write=False)
+    return values

--- a/tests/test_optics_foundation.py
+++ b/tests/test_optics_foundation.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.optics import (
+    apply_thin_element,
+    as_complex_field,
+    circular_aperture,
+    field_power,
+    gaussian_mode,
+    hermite_gaussian_mode,
+    make_optical_grid,
+    phase_only_mask,
+    rectangular_aperture,
+    thin_lens,
+)
+
+
+def test_optical_grid_uses_physical_sampling_and_read_only_coordinates() -> None:
+    grid = make_optical_grid((48, 64), (3.0e-3, 4.0e-3), 633.0e-9)
+
+    assert grid.shape == (48, 64)
+    assert grid.dy == pytest.approx(3.0e-3 / 48)
+    assert grid.dx == pytest.approx(4.0e-3 / 64)
+    assert grid.wave_number == pytest.approx(2.0 * np.pi / 633.0e-9)
+    assert grid.X.shape == grid.shape
+    assert grid.FX.shape == grid.shape
+    assert not grid.X.flags.writeable
+
+
+@pytest.mark.parametrize(
+    ("shape", "extent", "wavelength"),
+    [
+        (1, 1.0, 1.0),
+        (16, 0.0, 1.0),
+        (16, 1.0, -1.0),
+        ((16, 0), (1.0, 1.0), 1.0),
+    ],
+)
+def test_optical_grid_rejects_nonphysical_inputs(shape, extent, wavelength) -> None:
+    with pytest.raises(ValueError):
+        make_optical_grid(shape, extent, wavelength)
+
+
+def test_arbitrary_complex_field_is_copied_without_normalization() -> None:
+    grid = make_optical_grid(8, 2.0e-3, 532.0e-9)
+    values = np.full(grid.shape, 2.0 + 3.0j)
+
+    field = as_complex_field(values, grid)
+    field[0, 0] = 9.0
+
+    assert values[0, 0] == 2.0 + 3.0j
+    assert field_power(as_complex_field(values, grid), grid) == pytest.approx(
+        13.0 * 4.0e-6
+    )
+
+
+def test_gaussian_and_hg_modes_are_normalized_and_orthogonal() -> None:
+    grid = make_optical_grid(128, 8.0e-3, 1064.0e-9)
+    gaussian = gaussian_mode(grid, 0.7e-3)
+    hg10 = hermite_gaussian_mode(grid, (1, 0), 0.7e-3)
+    overlap = np.vdot(gaussian, hg10) * grid.sample_area
+
+    assert field_power(gaussian, grid) == pytest.approx(1.0, abs=1e-13)
+    assert field_power(hg10, grid) == pytest.approx(1.0, abs=1e-13)
+    assert abs(overlap) < 1e-14
+
+
+def test_apertures_are_binary_and_cannot_increase_power() -> None:
+    grid = make_optical_grid(64, 4.0e-3, 532.0e-9)
+    field = gaussian_mode(grid, 0.8e-3)
+    circular = circular_aperture(grid, 0.6e-3)
+    rectangular = rectangular_aperture(grid, (1.0e-3, 1.5e-3))
+
+    for aperture in (circular, rectangular):
+        assert set(np.unique(aperture)) <= {0.0, 1.0}
+        truncated = apply_thin_element(field, aperture, grid)
+        assert field_power(truncated, grid) <= field_power(field, grid)
+
+
+def test_lens_matches_paraxial_phase_and_preserves_power() -> None:
+    grid = make_optical_grid(64, 3.0e-3, 633.0e-9)
+    field = gaussian_mode(grid, 0.5e-3)
+    focal_length = 0.15
+    lens = thin_lens(grid, focal_length)
+    expected = np.exp(
+        -0.5j
+        * grid.wave_number
+        * (grid.X**2 + grid.Y**2)
+        / focal_length
+    )
+    output = apply_thin_element(field, lens, grid)
+
+    np.testing.assert_allclose(lens, expected, atol=1e-14, rtol=1e-14)
+    assert field_power(output, grid) == pytest.approx(1.0, abs=1e-13)
+
+
+def test_phase_mask_is_bounded_unit_magnitude_and_pure() -> None:
+    grid = make_optical_grid(32, 2.0e-3, 633.0e-9)
+    phase = np.linspace(-np.pi, np.pi, np.prod(grid.shape)).reshape(grid.shape)
+    before = phase.copy()
+    mask = phase_only_mask(phase, grid)
+
+    np.testing.assert_array_equal(phase, before)
+    np.testing.assert_allclose(np.abs(mask), 1.0, atol=1e-15)
+    with pytest.raises(ValueError, match="within bounds"):
+        phase_only_mask(phase + 0.1, grid)
+
+
+def test_thin_element_rejects_gain_and_shape_mismatch() -> None:
+    grid = make_optical_grid(8, 1.0e-3, 633.0e-9)
+    with pytest.raises(ValueError, match="cannot exceed one"):
+        apply_thin_element(np.ones(grid.shape), np.full(grid.shape, 1.01), grid)
+    with pytest.raises(ValueError, match="shape"):
+        as_complex_field(np.ones((4, 4)), grid)


### PR DESCRIPTION
Closes #32

## Change

Adds pure NumPy scalar-optics grids, arbitrary complex-field handling, normalized Gaussian and Hermite-Gaussian modes, circular and rectangular apertures, paraxial thin lenses, bounded phase-only masks, passive thin-element application, and documented physical/sign conventions.

Grid arrays are immutable, sampled arrays use `(y, x)` indexing, and HG mode orders use conventional `(x, y)` order so HG10 is `(1, 0)`.

## Validation and evidence

- `uv run pytest tests/test_optics_foundation.py tests/test_quantum_v0_1_regression.py -q` — 12 passed.
- `uv run pytest` — 46 passed.
- Gaussian and HG10 integrated-power errors are below `1e-13`.
- Fundamental/HG10 overlap is below `1e-14`.
- Thin-lens transmission agrees with the analytic paraxial phase at `1e-14` absolute/relative tolerance.
- Passive apertures do not increase power; unit-magnitude masks preserve power.
- Input copy/non-mutation, phase bounds, gain rejection, and physical grid validation are covered.

## Scientific scope

This is coherent monochromatic scalar free-space infrastructure. It does not claim polarization, vector-Maxwell, high-index integrated-photonics, propagation-model, differentiation, optimization, or robustness validity.

## Compatibility

The quantum solver, `quantum-lab`, configs, artifact schema, and dashboard remain unchanged and the frozen quantum v0.1 baseline stays green.

This is a stacked draft PR targeting the #28 branch.