### PR TITLE
Validate Fresnel and angular-spectrum propagation

### DIFF
--- a/benchmarks/reference/README.md
+++ b/benchmarks/reference/README.md
@@ -32,3 +32,20 @@ The recorded tolerances allow only floating-point/FFT roundoff across supported
 platforms. They are regression tolerances, not uncertainty estimates and not
 evidence that the current Zeno or double-slit interpretation is physically
 validated.
+
+## Scalar optics M1
+
+`optics_m1.json` records the analytic Gaussian, thin-lens focus, conservation,
+reversibility, grid/window convergence, retained-band, and Fresnel-to-angular-
+spectrum metrics that establish the M1 NumPy reference regime.
+
+Regenerate the file from the repository root with:
+
+```bash
+uv run python -m benchmarks.reference.generate_optics_m1
+```
+
+The limits are numerical acceptance thresholds for coherent monochromatic
+scalar free-space optics. Their trusted regime is documented in
+`docs/optics-model-validation.md`; they do not establish vector-Maxwell or
+high-index integrated-photonics accuracy.

--- a/benchmarks/reference/generate_optics_m1.py
+++ b/benchmarks/reference/generate_optics_m1.py
@@ -1,0 +1,147 @@
+"""Regenerate the small M1 scalar-optics reference metrics."""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from quantum_dynamics_lab.optics import (
+    apply_thin_element,
+    field_power,
+    gaussian_mode,
+    make_optical_grid,
+    thin_lens,
+)
+from quantum_dynamics_lab.optics_propagation import (
+    angular_spectrum_retained_power,
+    propagate_angular_spectrum,
+    propagate_fresnel,
+)
+
+
+REFERENCE_PATH = Path(__file__).with_name("optics_m1.json")
+
+
+def _relative_l2(actual: np.ndarray, expected: np.ndarray) -> float:
+    return float(np.linalg.norm(actual - expected) / np.linalg.norm(expected))
+
+
+def _analytic_gaussian(grid, waist: float, distance: float) -> np.ndarray:
+    envelope = np.exp(-(grid.X**2 + grid.Y**2) / waist**2)
+    amplitude = 1.0 / math.sqrt(field_power(envelope, grid))
+    rayleigh_range = math.pi * waist**2 / grid.wavelength
+    q = 1.0 + 1j * distance / rayleigh_range
+    return np.asarray(
+        amplitude
+        * np.exp(1j * grid.wave_number * distance)
+        * np.exp(-(grid.X**2 + grid.Y**2) / (waist**2 * q))
+        / q,
+        dtype=np.complex128,
+    )
+
+
+def _beam_waist(field: np.ndarray, grid) -> float:
+    intensity = np.abs(field) ** 2
+    variance = (
+        float(np.sum(intensity * grid.X**2, dtype=np.float64))
+        * grid.sample_area
+        / field_power(field, grid)
+    )
+    return 2.0 * math.sqrt(variance)
+
+
+def generate_metrics() -> dict[str, Any]:
+    wavelength = 1064.0e-9
+    waist = 0.45e-3
+    distance = 0.18
+    gaussian_errors = []
+    for n, extent in ((64, 3.0e-3), (128, 6.0e-3)):
+        grid = make_optical_grid(n, extent, wavelength)
+        propagated = propagate_fresnel(gaussian_mode(grid, waist), grid, distance)
+        gaussian_errors.append(
+            _relative_l2(propagated, _analytic_gaussian(grid, waist, distance))
+        )
+
+    grid = make_optical_grid(192, 6.0e-3, wavelength)
+    field = gaussian_mode(grid, 0.55e-3)
+    fresnel = propagate_fresnel(field, grid, 0.12)
+    angular = propagate_angular_spectrum(field, grid, 0.12)
+    reconstructed_fresnel = propagate_fresnel(fresnel, grid, -0.12)
+    reconstructed_angular = propagate_angular_spectrum(angular, grid, -0.12)
+
+    focus_grid = make_optical_grid(256, 4.0e-3, wavelength)
+    input_waist = 0.55e-3
+    focal_length = 0.18
+    focused = propagate_fresnel(
+        apply_thin_element(
+            gaussian_mode(focus_grid, input_waist),
+            thin_lens(focus_grid, focal_length),
+            focus_grid,
+        ),
+        focus_grid,
+        focal_length,
+    )
+    predicted_focus_waist = wavelength * focal_length / (math.pi * input_waist)
+
+    return {
+        "schema_version": 1,
+        "scope": "monochromatic coherent scalar free-space optics",
+        "configuration": {
+            "wavelength_m": wavelength,
+            "gaussian_waist_m": waist,
+            "gaussian_distance_m": distance,
+            "cross_model_grid": 192,
+            "cross_model_extent_m": 6.0e-3,
+            "cross_model_waist_m": 0.55e-3,
+            "cross_model_distance_m": 0.12,
+        },
+        "metrics": {
+            "gaussian_relative_l2_coarse": gaussian_errors[0],
+            "gaussian_relative_l2_fine": gaussian_errors[1],
+            "gaussian_convergence_ratio": gaussian_errors[1] / gaussian_errors[0],
+            "focal_waist_relative_error": abs(
+                _beam_waist(focused, focus_grid) / predicted_focus_waist - 1.0
+            ),
+            "fresnel_power_relative_drift": abs(field_power(fresnel, grid) - 1.0),
+            "fresnel_reverse_max_error": float(
+                np.max(np.abs(reconstructed_fresnel - field))
+            ),
+            "angular_retained_spectral_power": angular_spectrum_retained_power(
+                field, grid, 0.12
+            ),
+            "angular_power_relative_drift": abs(field_power(angular, grid) - 1.0),
+            "angular_reverse_max_error": float(
+                np.max(np.abs(reconstructed_angular - field))
+            ),
+            "cross_model_complex_relative_l2": _relative_l2(angular, fresnel),
+            "cross_model_intensity_relative_l2": _relative_l2(
+                np.abs(angular) ** 2,
+                np.abs(fresnel) ** 2,
+            ),
+        },
+        "declared_limits": {
+            "gaussian_relative_l2_fine_max": 1.0e-9,
+            "gaussian_convergence_ratio_max": 1.0e-4,
+            "focal_waist_relative_error_max": 1.0e-2,
+            "power_relative_drift_max": 1.0e-13,
+            "reverse_max_error_max": 1.0e-10,
+            "cross_model_relative_l2_max": 5.0e-6,
+            "minimum_retained_spectral_power": 1.0 - 1.0e-13,
+        },
+    }
+
+
+def main() -> None:
+    REFERENCE_PATH.write_text(
+        json.dumps(generate_metrics(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(REFERENCE_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reference/optics_m1.json
+++ b/benchmarks/reference/optics_m1.json
@@ -1,0 +1,35 @@
+{
+  "schema_version": 1,
+  "scope": "monochromatic coherent scalar free-space optics",
+  "configuration": {
+    "wavelength_m": 1.064e-06,
+    "gaussian_waist_m": 0.00045,
+    "gaussian_distance_m": 0.18,
+    "cross_model_grid": 192,
+    "cross_model_extent_m": 0.006,
+    "cross_model_waist_m": 0.00055,
+    "cross_model_distance_m": 0.12
+  },
+  "metrics": {
+    "gaussian_relative_l2_coarse": 2.430056748786594e-05,
+    "gaussian_relative_l2_fine": 6.2077594479344e-11,
+    "gaussian_convergence_ratio": 2.5545738596574486e-06,
+    "focal_waist_relative_error": 5.49591483434142e-11,
+    "fresnel_power_relative_drift": 2.220446049250313e-16,
+    "fresnel_reverse_max_error": 6.885699021235836e-13,
+    "angular_retained_spectral_power": 1.0,
+    "angular_power_relative_drift": 0.0,
+    "angular_reverse_max_error": 6.897620878004985e-13,
+    "cross_model_complex_relative_l2": 1.5596658134410832e-08,
+    "cross_model_intensity_relative_l2": 8.432662212334868e-09
+  },
+  "declared_limits": {
+    "gaussian_relative_l2_fine_max": 1e-09,
+    "gaussian_convergence_ratio_max": 0.0001,
+    "focal_waist_relative_error_max": 0.01,
+    "power_relative_drift_max": 1e-13,
+    "reverse_max_error_max": 1e-10,
+    "cross_model_relative_l2_max": 5e-06,
+    "minimum_retained_spectral_power": 0.9999999999999
+  }
+}

--- a/docs/optics-model-validation.md
+++ b/docs/optics-model-validation.md
@@ -1,0 +1,49 @@
+# M1 Optics Model Validation
+
+The NumPy reference layer contains two separately formulated free-space models:
+
+- Fresnel propagation uses the paraxial transfer phase
+  `exp(i*k*z - i*pi*lambda*z*(fx^2+fy^2))`.
+- Band-limited angular spectrum (BLAS) uses exact scalar longitudinal dispersion
+  `exp(i*k*z*sqrt(1-lambda^2*(fx^2+fy^2)))`, rejects evanescent samples, and
+  applies distance/window-dependent alias-safe rectangular limits.
+
+Both use periodic FFT boundaries. A field must be padded so that negligible
+power reaches the transverse window boundary. Negative distance reverses phase;
+BLAS reversibility additionally requires the input spectrum to lie inside the
+retained band.
+
+## Committed Evidence
+
+`benchmarks/reference/optics_m1.json` records deterministic analytic Gaussian,
+thin-lens focus, conservation, reversibility, grid/window convergence, retained
+spectral power, and cross-model metrics. Regenerate it with:
+
+```bash
+uv run python -m benchmarks.reference.generate_optics_m1
+```
+
+The evidence uses a 1064 nm wavelength, sub-millimetre Gaussian waists,
+12--18 cm propagation, and windows at least 6 mm across for the final
+comparisons. Doubling both grid count and window width at fixed sampling reduces
+the analytic Gaussian boundary error by more than four orders of magnitude.
+
+## Trusted Regime
+
+Treat a result as numerically trusted only when all of the following hold:
+
+1. sampled input and output have negligible power at the window boundary;
+2. BLAS retains effectively all significant spectral power (the M1 reference
+   requires at least `1 - 1e-13`);
+3. halving sample spacing and increasing padding do not materially change the
+   reported metric;
+4. Fresnel and BLAS agree at the tolerance appropriate to the claim (the M1
+   paraxial reference requires relative complex-field and intensity errors below
+   `5e-6`);
+5. the physical problem is monochromatic, coherent, scalar, and free-space.
+
+Fresnel error grows with angular content because it replaces exact longitudinal
+dispersion with its paraxial expansion. BLAS is the independent scalar transfer
+model for later model-transfer evaluation; agreement between the two does not
+establish vector-Maxwell accuracy, polarization behavior, or validity for
+high-index integrated photonics.

--- a/src/quantum_dynamics_lab/optics_propagation.py
+++ b/src/quantum_dynamics_lab/optics_propagation.py
@@ -1,0 +1,157 @@
+"""Validated NumPy reference propagators for scalar free-space optics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from .optics import ComplexArray, FloatArray, OpticalGrid, as_complex_field
+
+__all__ = [
+    "angular_spectrum_bandlimit",
+    "angular_spectrum_retained_power",
+    "angular_spectrum_transfer_function",
+    "fresnel_transfer_function",
+    "propagate_angular_spectrum",
+    "propagate_fresnel",
+]
+
+
+def fresnel_transfer_function(
+    grid: OpticalGrid,
+    distance: float,
+) -> ComplexArray:
+    """Return the paraxial transfer function including carrier phase."""
+
+    distance = _finite_distance(distance)
+    radial_frequency_squared = grid.FX**2 + grid.FY**2
+    phase = (
+        grid.wave_number * distance
+        - math.pi * grid.wavelength * distance * radial_frequency_squared
+    )
+    return np.asarray(np.exp(1j * phase), dtype=np.complex128)
+
+
+def propagate_fresnel(
+    field: ArrayLike,
+    grid: OpticalGrid,
+    distance: float,
+) -> ComplexArray:
+    """Propagate a sampled field with the paraxial Fresnel transfer method."""
+
+    values = as_complex_field(field, grid)
+    transfer = fresnel_transfer_function(grid, distance)
+    return np.asarray(
+        np.fft.ifft2(np.fft.fft2(values) * transfer),
+        dtype=np.complex128,
+    )
+
+
+def angular_spectrum_bandlimit(
+    grid: OpticalGrid,
+    distance: float,
+) -> FloatArray:
+    """Return the propagating, alias-safe rectangular BLAS support mask.
+
+    The distance-dependent limits follow the finite-window band-limited angular
+    spectrum condition. Nyquist limits are implicit in the sampled FFT grid.
+    """
+
+    distance = abs(_finite_distance(distance))
+    if distance == 0.0:
+        return np.ones(grid.shape, dtype=np.float64)
+    ly, lx = grid.extent
+    fx_limit = 1.0 / (
+        grid.wavelength * math.sqrt(1.0 + (2.0 * distance / lx) ** 2)
+    )
+    fy_limit = 1.0 / (
+        grid.wavelength * math.sqrt(1.0 + (2.0 * distance / ly) ** 2)
+    )
+    propagating = (
+        grid.wavelength**2 * (grid.FX**2 + grid.FY**2)
+        <= 1.0 + 8.0 * np.finfo(np.float64).eps
+    )
+    return np.asarray(
+        propagating
+        & (np.abs(grid.FX) <= fx_limit)
+        & (np.abs(grid.FY) <= fy_limit),
+        dtype=np.float64,
+    )
+
+
+def angular_spectrum_transfer_function(
+    grid: OpticalGrid,
+    distance: float,
+    *,
+    bandlimit: bool = True,
+) -> ComplexArray:
+    """Return the exact propagating-wave angular-spectrum transfer function."""
+
+    distance = _finite_distance(distance)
+    if distance == 0.0:
+        return np.ones(grid.shape, dtype=np.complex128)
+    normalized_radial_frequency = grid.wavelength**2 * (
+        grid.FX**2 + grid.FY**2
+    )
+    propagating = normalized_radial_frequency <= 1.0
+    longitudinal_factor = np.sqrt(
+        np.clip(1.0 - normalized_radial_frequency, 0.0, None)
+    )
+    transfer = np.zeros(grid.shape, dtype=np.complex128)
+    transfer[propagating] = np.exp(
+        1j * grid.wave_number * distance * longitudinal_factor[propagating]
+    )
+    if bandlimit:
+        transfer *= angular_spectrum_bandlimit(grid, distance)
+    return transfer
+
+
+def propagate_angular_spectrum(
+    field: ArrayLike,
+    grid: OpticalGrid,
+    distance: float,
+    *,
+    bandlimit: bool = True,
+) -> ComplexArray:
+    """Propagate with exact scalar dispersion and optional BLAS filtering."""
+
+    values = as_complex_field(field, grid)
+    transfer = angular_spectrum_transfer_function(
+        grid,
+        distance,
+        bandlimit=bandlimit,
+    )
+    return np.asarray(
+        np.fft.ifft2(np.fft.fft2(values) * transfer),
+        dtype=np.complex128,
+    )
+
+
+def angular_spectrum_retained_power(
+    field: ArrayLike,
+    grid: OpticalGrid,
+    distance: float,
+) -> float:
+    """Return the fraction of sampled spectral power retained by BLAS support."""
+
+    values = as_complex_field(field, grid)
+    spectral_power = np.abs(np.fft.fft2(values)) ** 2
+    total = float(np.sum(spectral_power, dtype=np.float64))
+    if total <= 0.0 or not math.isfinite(total):
+        raise ValueError("field spectral power must be finite and positive")
+    retained = float(
+        np.sum(
+            spectral_power * angular_spectrum_bandlimit(grid, distance),
+            dtype=np.float64,
+        )
+    )
+    return retained / total
+
+
+def _finite_distance(distance: float) -> float:
+    converted = float(distance)
+    if not math.isfinite(converted):
+        raise ValueError("distance must be finite")
+    return converted

--- a/tests/test_optics_m1_reference.py
+++ b/tests/test_optics_m1_reference.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+REFERENCE_PATH = REPOSITORY_ROOT / "benchmarks" / "reference" / "optics_m1.json"
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.reference.generate_optics_m1 import generate_metrics
+
+
+def test_optics_m1_reference_metrics_meet_declared_limits() -> None:
+    reference = json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+    regenerated = generate_metrics()
+
+    assert reference["schema_version"] == 1
+    assert regenerated["configuration"] == reference["configuration"]
+    metrics = regenerated["metrics"]
+    limits = reference["declared_limits"]
+    assert metrics["gaussian_relative_l2_fine"] < limits[
+        "gaussian_relative_l2_fine_max"
+    ]
+    assert metrics["gaussian_convergence_ratio"] < limits[
+        "gaussian_convergence_ratio_max"
+    ]
+    assert metrics["focal_waist_relative_error"] < limits[
+        "focal_waist_relative_error_max"
+    ]
+    assert metrics["fresnel_power_relative_drift"] < limits[
+        "power_relative_drift_max"
+    ]
+    assert metrics["angular_power_relative_drift"] < limits[
+        "power_relative_drift_max"
+    ]
+    assert metrics["fresnel_reverse_max_error"] < limits["reverse_max_error_max"]
+    assert metrics["angular_reverse_max_error"] < limits["reverse_max_error_max"]
+    assert metrics["cross_model_complex_relative_l2"] < limits[
+        "cross_model_relative_l2_max"
+    ]
+    assert metrics["cross_model_intensity_relative_l2"] < limits[
+        "cross_model_relative_l2_max"
+    ]
+    assert metrics["angular_retained_spectral_power"] > limits[
+        "minimum_retained_spectral_power"
+    ]

--- a/tests/test_optics_propagation.py
+++ b/tests/test_optics_propagation.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.optics import (
+    apply_thin_element,
+    field_power,
+    gaussian_mode,
+    make_optical_grid,
+    thin_lens,
+)
+from quantum_dynamics_lab.optics_propagation import (
+    angular_spectrum_bandlimit,
+    angular_spectrum_retained_power,
+    propagate_angular_spectrum,
+    propagate_fresnel,
+)
+
+
+def _analytic_gaussian(grid, waist: float, distance: float):
+    envelope = np.exp(-(grid.X**2 + grid.Y**2) / waist**2)
+    amplitude = 1.0 / math.sqrt(field_power(envelope, grid))
+    rayleigh_range = math.pi * waist**2 / grid.wavelength
+    q = 1.0 + 1j * distance / rayleigh_range
+    return np.asarray(
+        amplitude
+        * np.exp(1j * grid.wave_number * distance)
+        * np.exp(-(grid.X**2 + grid.Y**2) / (waist**2 * q))
+        / q,
+        dtype=np.complex128,
+    )
+
+
+def _relative_l2(actual, expected) -> float:
+    return float(np.linalg.norm(actual - expected) / np.linalg.norm(expected))
+
+
+def _beam_waist(field, grid) -> float:
+    intensity = np.abs(field) ** 2
+    power = field_power(field, grid)
+    x_variance = (
+        float(np.sum(intensity * grid.X**2, dtype=np.float64))
+        * grid.sample_area
+        / power
+    )
+    return 2.0 * math.sqrt(x_variance)
+
+
+def test_fresnel_matches_analytic_gaussian_and_converges() -> None:
+    wavelength = 1064.0e-9
+    waist = 0.45e-3
+    distance = 0.18
+    errors = []
+
+    for n, extent in ((64, 3.0e-3), (128, 6.0e-3)):
+        grid = make_optical_grid(n, extent, wavelength)
+        propagated = propagate_fresnel(
+            gaussian_mode(grid, waist),
+            grid,
+            distance,
+        )
+        errors.append(
+            _relative_l2(propagated, _analytic_gaussian(grid, waist, distance))
+        )
+
+    assert errors[1] < errors[0] * 1e-4
+    assert errors[1] < 1e-9
+
+
+def test_fresnel_is_power_conserving_and_reversible() -> None:
+    grid = make_optical_grid((48, 64), (4.0e-3, 5.0e-3), 633.0e-9)
+    rng = np.random.default_rng(34)
+    field = rng.standard_normal(grid.shape) + 1j * rng.standard_normal(grid.shape)
+    before = field_power(field, grid)
+
+    propagated = propagate_fresnel(field, grid, 0.07)
+    reconstructed = propagate_fresnel(propagated, grid, -0.07)
+
+    assert abs(field_power(propagated, grid) - before) / before < 1e-14
+    assert np.max(np.abs(reconstructed - field)) < 3e-15
+
+
+def test_lens_focus_matches_predicted_gaussian_waist() -> None:
+    wavelength = 1064.0e-9
+    input_waist = 0.55e-3
+    focal_length = 0.18
+    grid = make_optical_grid(256, 4.0e-3, wavelength)
+    field = gaussian_mode(grid, input_waist)
+    focused = propagate_fresnel(
+        apply_thin_element(field, thin_lens(grid, focal_length), grid),
+        grid,
+        focal_length,
+    )
+    expected_waist = wavelength * focal_length / (math.pi * input_waist)
+
+    assert abs(_beam_waist(focused, grid) / expected_waist - 1.0) < 0.01
+
+
+def test_angular_spectrum_is_conservative_and_reversible_in_retained_band() -> None:
+    grid = make_optical_grid(128, 5.0e-3, 1064.0e-9)
+    field = gaussian_mode(grid, 0.5e-3)
+    retained = angular_spectrum_retained_power(field, grid, 0.12)
+
+    propagated = propagate_angular_spectrum(field, grid, 0.12)
+    reconstructed = propagate_angular_spectrum(propagated, grid, -0.12)
+
+    assert 1.0 - retained < 1e-14
+    assert abs(field_power(propagated, grid) - 1.0) < 1e-13
+    assert np.max(np.abs(reconstructed - field)) < 1e-11
+
+
+def test_bandlimit_rejects_alias_prone_spectrum() -> None:
+    grid = make_optical_grid(64, 1.0e-3, 532.0e-9)
+    mask = angular_spectrum_bandlimit(grid, 2.0)
+    checkerboard = (-1.0) ** (
+        np.indices(grid.shape)[0] + np.indices(grid.shape)[1]
+    )
+
+    assert np.count_nonzero(mask) < mask.size
+    assert angular_spectrum_retained_power(checkerboard, grid, 2.0) < 1e-15
+    rejected = propagate_angular_spectrum(checkerboard, grid, 2.0)
+    assert field_power(rejected, grid) < 1e-20
+
+
+def test_models_agree_in_declared_paraxial_regime() -> None:
+    grid = make_optical_grid(192, 6.0e-3, 1064.0e-9)
+    field = gaussian_mode(grid, 0.55e-3)
+    distance = 0.12
+
+    fresnel = propagate_fresnel(field, grid, distance)
+    angular = propagate_angular_spectrum(field, grid, distance)
+
+    assert angular_spectrum_retained_power(field, grid, distance) > 1.0 - 1e-14
+    assert _relative_l2(angular, fresnel) < 5e-6
+    intensity_error = _relative_l2(np.abs(angular) ** 2, np.abs(fresnel) ** 2)
+    assert intensity_error < 5e-6
+
+
+def test_propagators_reject_nonfinite_distance_and_preserve_inputs() -> None:
+    grid = make_optical_grid(16, 1.0e-3, 633.0e-9)
+    field = gaussian_mode(grid, 0.2e-3)
+    before = field.copy()
+    with pytest.raises(ValueError, match="distance"):
+        propagate_fresnel(field, grid, float("nan"))
+    with pytest.raises(ValueError, match="distance"):
+        propagate_angular_spectrum(field, grid, float("inf"))
+    np.testing.assert_array_equal(field, before)


### PR DESCRIPTION
Closes #34

## Change

Adds independently formulated NumPy reference propagators for paraxial Fresnel transfer and exact-dispersion band-limited angular spectrum (BLAS). BLAS rejects evanescent samples and applies distance/window-dependent alias-safe support. Signed distances, rectangular grids, retained-spectrum diagnostics, deterministic reference metrics, regeneration code, and trusted-regime documentation are included.

## Validation and evidence

- Focused optics/model/quantum evidence — 9 passed.
- `uv run pytest` — 54 passed.
- Analytic Gaussian fine-grid relative L2 error: `6.2078e-11`.
- Coarse-to-fine analytic error ratio: `2.5546e-6`.
- Thin-lens focal-waist relative error: `5.4959e-11`.
- Fresnel and BLAS power drift: at or below `2.23e-16`.
- Forward/reverse max errors: below `7e-13`.
- Retained BLAS spectral power in the reference regime: `1.0`.
- Fresnel-to-BLAS complex relative L2 error: `1.5597e-8`.
- Fresnel-to-BLAS intensity relative L2 error: `8.4327e-9`.

The small reference is committed at `benchmarks/reference/optics_m1.json`; full fields remain untracked.

## Trusted regime and interpretation

The documented regime requires padded fields, negligible boundary power, converged sampling/window results, effectively complete BLAS retained power, and explicit Fresnel/BLAS agreement. These checks validate monochromatic coherent scalar free-space propagation only; they do not establish vector-Maxwell, polarization, or high-index integrated-photonics accuracy.

## Compatibility

Quantum v0.1, `quantum-lab`, configs, artifacts, and dashboard tests remain green and unchanged.

This is a stacked draft PR targeting the #32 branch.