### PR TITLE
Add wave-lab forward propagation CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,12 @@ direction and milestone gates; it is not a daily task list.
 
 ## Current Priority
 
-**M0 - Pivot foundation** is complete. The next behavioral work is the first
-part of **M1 - Forward optics v0.2**: extract a pure, backend-neutral
-propagation kernel and then make the maintained quantum solver delegate to it
-without changing recorded quantum v0.1 results. Do not add JAX, optimization,
-or more dashboard features ahead of that compatibility-preserving refactor.
+**M0 - Pivot foundation** and **M1 - Forward optics v0.2** are complete. The
+next behavioral work is **M2 - Differentiable solver v0.3**: add optional JAX
+execution without replacing NumPy as the correctness reference, establish
+value parity, add array-native objectives, and validate gradients with centered
+directional finite differences. Do not add the optimization engine or more
+dashboard features ahead of those differentiation gates.
 
 ## Project Invariants
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -48,7 +48,7 @@ M0 Pivot foundation
 | Milestone | Status | Outcome |
 | --- | --- | --- |
 | M0 - Pivot foundation | Complete | Durable context, workflow templates, accepted decisions, corrected framing, and a frozen quantum v0.1 regression baseline |
-| M1 - Forward optics v0.2 | Planned | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
+| M1 - Forward optics v0.2 | Complete | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
 | M2 - Differentiable solver v0.3 | Planned | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
 | M3 - Inverse-design MVP v0.4 | Planned | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
 | M4 - Robust flagship v1.0 | Planned | Robust multi-plane mode conversion, held-out perturbation results, cross-model validation, and the new CLI/dashboard identity |

--- a/docs/scalar-optics-conventions.md
+++ b/docs/scalar-optics-conventions.md
@@ -29,3 +29,17 @@ Apertures are passive binary transmissions. Phase-only masks must lie inside
 their declared phase bounds and have unit magnitude. Thin-element application
 rejects gain, does not mutate its inputs, and remains separate from propagation,
 configuration, plotting, artifact writing, experiments, and dashboards.
+
+## Forward CLI
+
+Run the committed Gaussian-through-lens example with:
+
+```bash
+uv run wave-lab propagate examples/gaussian_lens.toml --out runs/gaussian-lens
+```
+
+The optics TOML schema is separate from the legacy quantum schema. Ordered
+`[[steps]]` may apply lenses, circular or rectangular apertures, bounded
+sinusoidal phase masks, and Fresnel or BLAS propagation. The output directory
+contains input/final fields, resolved config, provenance, and concise metrics.
+The existing `quantum-lab` commands and artifacts remain available unchanged.

--- a/examples/gaussian_lens.toml
+++ b/examples/gaussian_lens.toml
@@ -1,0 +1,20 @@
+name = "gaussian_lens_focus"
+
+[grid]
+shape = 256
+extent_m = 0.004
+wavelength_m = 1.064e-6
+
+[source]
+kind = "gaussian"
+waist_m = 0.00055
+center_m = [0.0, 0.0]
+
+[[steps]]
+kind = "lens"
+focal_length_m = 0.18
+
+[[steps]]
+kind = "propagate"
+model = "fresnel"
+distance_m = 0.18

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ ui = [
 
 [project.scripts]
 quantum-lab = "quantum_dynamics_lab.cli:main"
+wave-lab = "quantum_dynamics_lab.wave_cli:main"
 
 [dependency-groups]
 dev = [

--- a/src/quantum_dynamics_lab/wave_artifacts.py
+++ b/src/quantum_dynamics_lab/wave_artifacts.py
@@ -1,0 +1,59 @@
+"""Artifact persistence for scalar-optics forward runs."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+import json
+import platform
+import subprocess
+
+import numpy as np
+
+from . import __version__
+from .wave_experiments import WaveRun
+
+
+def save_wave_run(run: WaveRun, out_dir: str | Path) -> Path:
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_path = out_dir / "wave_run.npz"
+    metadata = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "package_version": __version__,
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "git_commit": _git_value("rev-parse", "HEAD"),
+        "git_dirty": bool(_git_value("status", "--porcelain")),
+        "config": run.config.to_dict(),
+    }
+    np.savez_compressed(
+        run_path,
+        x=run.grid.x,
+        y=run.grid.y,
+        input_field=run.input_field,
+        final_field=run.final_field,
+        metadata=json.dumps(metadata, indent=2, sort_keys=True),
+    )
+    (out_dir / "metrics.json").write_text(
+        json.dumps(run.metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "resolved_config.json").write_text(
+        json.dumps(run.config.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return run_path
+
+
+def _git_value(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip()

--- a/src/quantum_dynamics_lab/wave_cli.py
+++ b/src/quantum_dynamics_lab/wave_cli.py
@@ -1,0 +1,36 @@
+"""Command-line interface for scalar wave propagation and inverse design."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .wave_artifacts import save_wave_run
+from .wave_config import load_wave_config
+from .wave_experiments import run_wave_propagation
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="wave-lab",
+        description="Differentiable 2D wave propagation and inverse-design lab",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    propagate_parser = subparsers.add_parser(
+        "propagate",
+        help="Run a scalar-optics forward config",
+    )
+    propagate_parser.add_argument("config", type=Path)
+    propagate_parser.add_argument("--out", type=Path, required=True)
+
+    args = parser.parse_args(argv)
+    if args.command == "propagate":
+        config = load_wave_config(args.config)
+        run_path = save_wave_run(run_wave_propagation(config), args.out)
+        print(run_path)
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/quantum_dynamics_lab/wave_config.py
+++ b/src/quantum_dynamics_lab/wave_config.py
@@ -1,0 +1,146 @@
+"""Typed TOML configuration for scalar-optics forward runs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+import tomllib
+
+
+@dataclass(frozen=True)
+class OpticalGridConfig:
+    shape: tuple[int, int] = (128, 128)
+    extent_m: tuple[float, float] = (6.0e-3, 6.0e-3)
+    wavelength_m: float = 1064.0e-9
+
+
+@dataclass(frozen=True)
+class OpticalSourceConfig:
+    kind: str = "gaussian"
+    waist_m: float = 0.5e-3
+    center_m: tuple[float, float] = (0.0, 0.0)
+    order: tuple[int, int] = (0, 0)
+    path: Path | None = None
+    array_key: str = "field"
+
+
+@dataclass(frozen=True)
+class OpticalStepConfig:
+    kind: str
+    model: str = "fresnel"
+    distance_m: float | None = None
+    focal_length_m: float | None = None
+    radius_m: float | None = None
+    size_m: tuple[float, float] | None = None
+    center_m: tuple[float, float] = (0.0, 0.0)
+    phase_profile: str = "sinusoidal"
+    phase_amplitude_rad: float = 0.0
+    phase_period_m: float | None = None
+    axis: str = "x"
+
+
+@dataclass(frozen=True)
+class WavePropagationConfig:
+    name: str = "wave_propagation"
+    grid: OpticalGridConfig = field(default_factory=OpticalGridConfig)
+    source: OpticalSourceConfig = field(default_factory=OpticalSourceConfig)
+    steps: tuple[OpticalStepConfig, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        if self.source.path is not None:
+            data["source"]["path"] = str(self.source.path)
+        return data
+
+
+def load_wave_config(path: str | Path) -> WavePropagationConfig:
+    """Load an optics run without sharing the legacy quantum config schema."""
+
+    path = Path(path).resolve()
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    grid_data = _table(data, "grid")
+    source_data = _table(data, "source")
+    source_path = source_data.get("path")
+    resolved_source_path = None
+    if source_path is not None:
+        resolved_source_path = Path(str(source_path))
+        if not resolved_source_path.is_absolute():
+            resolved_source_path = path.parent / resolved_source_path
+        resolved_source_path = resolved_source_path.resolve()
+
+    raw_steps = data.get("steps", [])
+    if not isinstance(raw_steps, list):
+        raise ValueError("[[steps]] must be an array of TOML tables")
+    steps = []
+    for index, item in enumerate(raw_steps):
+        if not isinstance(item, dict) or "kind" not in item:
+            raise ValueError(f"steps[{index}] must be a table with a kind")
+        raw_size = item.get("size_m")
+        steps.append(
+            OpticalStepConfig(
+                kind=str(item["kind"]),
+                model=str(item.get("model", "fresnel")),
+                distance_m=_optional_float(item.get("distance_m")),
+                focal_length_m=_optional_float(item.get("focal_length_m")),
+                radius_m=_optional_float(item.get("radius_m")),
+                size_m=None if raw_size is None else _float_pair(raw_size, "size_m"),
+                center_m=_float_pair(
+                    item.get("center_m", (0.0, 0.0)),
+                    "center_m",
+                ),
+                phase_profile=str(item.get("phase_profile", "sinusoidal")),
+                phase_amplitude_rad=float(item.get("phase_amplitude_rad", 0.0)),
+                phase_period_m=_optional_float(item.get("phase_period_m")),
+                axis=str(item.get("axis", "x")),
+            )
+        )
+
+    return WavePropagationConfig(
+        name=str(data.get("name", path.stem)),
+        grid=OpticalGridConfig(
+            shape=_int_pair(grid_data.get("shape", 128), "grid.shape"),
+            extent_m=_float_pair(
+                grid_data.get("extent_m", 6.0e-3),
+                "grid.extent_m",
+            ),
+            wavelength_m=float(grid_data.get("wavelength_m", 1064.0e-9)),
+        ),
+        source=OpticalSourceConfig(
+            kind=str(source_data.get("kind", "gaussian")),
+            waist_m=float(source_data.get("waist_m", 0.5e-3)),
+            center_m=_float_pair(
+                source_data.get("center_m", (0.0, 0.0)),
+                "source.center_m",
+            ),
+            order=_int_pair(source_data.get("order", (0, 0)), "source.order"),
+            path=resolved_source_path,
+            array_key=str(source_data.get("array_key", "field")),
+        ),
+        steps=tuple(steps),
+    )
+
+
+def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data.get(name, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"[{name}] must be a TOML table")
+    return value
+
+
+def _int_pair(value: Any, name: str) -> tuple[int, int]:
+    values = (value, value) if isinstance(value, int) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be an integer or two-item array")
+    return int(values[0]), int(values[1])
+
+
+def _float_pair(value: Any, name: str) -> tuple[float, float]:
+    values = (value, value) if isinstance(value, (int, float)) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be a number or two-item array")
+    return float(values[0]), float(values[1])
+
+
+def _optional_float(value: Any) -> float | None:
+    return None if value is None else float(value)

--- a/src/quantum_dynamics_lab/wave_experiments.py
+++ b/src/quantum_dynamics_lab/wave_experiments.py
@@ -1,0 +1,215 @@
+"""Configuration adapter for scalar-optics forward experiments."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .optics import (
+    ComplexArray,
+    OpticalGrid,
+    apply_thin_element,
+    circular_aperture,
+    field_power,
+    gaussian_mode,
+    hermite_gaussian_mode,
+    make_optical_grid,
+    phase_only_mask,
+    rectangular_aperture,
+    thin_lens,
+)
+from .optics_propagation import (
+    angular_spectrum_retained_power,
+    propagate_angular_spectrum,
+    propagate_fresnel,
+)
+from .wave_config import OpticalSourceConfig, OpticalStepConfig, WavePropagationConfig
+
+
+@dataclass(frozen=True)
+class WaveRun:
+    config: WavePropagationConfig
+    grid: OpticalGrid
+    input_field: ComplexArray
+    final_field: ComplexArray
+    metrics: dict[str, Any]
+
+
+def run_wave_propagation(config: WavePropagationConfig) -> WaveRun:
+    """Execute ordered thin-element and propagation steps with NumPy."""
+
+    grid = make_optical_grid(
+        config.grid.shape,
+        config.grid.extent_m,
+        config.grid.wavelength_m,
+    )
+    input_field = _make_source(config.source, grid)
+    field = input_field.copy()
+    stage_metrics = []
+    total_distance = 0.0
+    for index, step in enumerate(config.steps):
+        before = field_power(field, grid)
+        details: dict[str, Any] = {"index": index, "kind": step.kind}
+        field = _apply_step(field, grid, step, details)
+        if step.kind.lower() == "propagate":
+            total_distance += float(step.distance_m or 0.0)
+        details["power_before"] = before
+        details["power_after"] = field_power(field, grid)
+        stage_metrics.append(details)
+
+    input_power = field_power(input_field, grid)
+    final_power = field_power(field, grid)
+    metrics = {
+        "name": config.name,
+        "scope": "monochromatic coherent scalar free-space optics",
+        "backend": "numpy",
+        "wavelength_m": grid.wavelength,
+        "shape": list(grid.shape),
+        "extent_m": list(grid.extent),
+        "sampling_m": [grid.dy, grid.dx],
+        "input_power": input_power,
+        "final_power": final_power,
+        "power_efficiency": final_power / input_power,
+        "total_distance_m": total_distance,
+        "output_second_moment_waist_m": list(_second_moment_waist(field, grid)),
+        "stages": stage_metrics,
+    }
+    return WaveRun(
+        config=config,
+        grid=grid,
+        input_field=input_field,
+        final_field=field,
+        metrics=metrics,
+    )
+
+
+def _make_source(source: OpticalSourceConfig, grid: OpticalGrid) -> ComplexArray:
+    kind = source.kind.lower()
+    if kind == "gaussian":
+        return gaussian_mode(grid, source.waist_m, center=source.center_m)
+    if kind in {"hermite_gaussian", "hg"}:
+        return hermite_gaussian_mode(
+            grid,
+            source.order,
+            source.waist_m,
+            center=source.center_m,
+        )
+    if kind in {"array", "complex_array"}:
+        if source.path is None:
+            raise ValueError("array source requires source.path")
+        if source.path.suffix.lower() == ".npy":
+            values = np.load(source.path)
+        elif source.path.suffix.lower() == ".npz":
+            with np.load(source.path) as archive:
+                if source.array_key not in archive:
+                    raise ValueError(
+                        f"array source key {source.array_key!r} is not present"
+                    )
+                values = archive[source.array_key]
+        else:
+            raise ValueError("array source path must end in .npy or .npz")
+        from .optics import as_complex_field
+
+        return as_complex_field(values, grid)
+    raise ValueError(f"unsupported optical source kind: {source.kind}")
+
+
+def _apply_step(
+    field: ComplexArray,
+    grid: OpticalGrid,
+    step: OpticalStepConfig,
+    details: dict[str, Any],
+) -> ComplexArray:
+    kind = step.kind.lower()
+    if kind == "lens":
+        if step.focal_length_m is None:
+            raise ValueError("lens step requires focal_length_m")
+        details["focal_length_m"] = step.focal_length_m
+        return apply_thin_element(
+            field,
+            thin_lens(grid, step.focal_length_m, center=step.center_m),
+            grid,
+        )
+    if kind == "circular_aperture":
+        if step.radius_m is None:
+            raise ValueError("circular_aperture step requires radius_m")
+        details["radius_m"] = step.radius_m
+        return apply_thin_element(
+            field,
+            circular_aperture(grid, step.radius_m, center=step.center_m),
+            grid,
+        )
+    if kind == "rectangular_aperture":
+        if step.size_m is None:
+            raise ValueError("rectangular_aperture step requires size_m")
+        details["size_m"] = list(step.size_m)
+        return apply_thin_element(
+            field,
+            rectangular_aperture(grid, step.size_m, center=step.center_m),
+            grid,
+        )
+    if kind == "phase_mask":
+        phase = _analytic_phase(step, grid)
+        details.update(
+            {
+                "phase_profile": step.phase_profile,
+                "phase_amplitude_rad": step.phase_amplitude_rad,
+                "phase_period_m": step.phase_period_m,
+                "axis": step.axis,
+            }
+        )
+        return apply_thin_element(field, phase_only_mask(phase, grid), grid)
+    if kind == "propagate":
+        if step.distance_m is None:
+            raise ValueError("propagate step requires distance_m")
+        model = step.model.lower()
+        details.update({"model": model, "distance_m": step.distance_m})
+        if model == "fresnel":
+            return propagate_fresnel(field, grid, step.distance_m)
+        if model in {"angular_spectrum", "blas"}:
+            details["retained_spectral_power"] = angular_spectrum_retained_power(
+                field,
+                grid,
+                step.distance_m,
+            )
+            return propagate_angular_spectrum(field, grid, step.distance_m)
+        raise ValueError(f"unsupported propagation model: {step.model}")
+    raise ValueError(f"unsupported optical step kind: {step.kind}")
+
+
+def _analytic_phase(step: OpticalStepConfig, grid: OpticalGrid) -> np.ndarray:
+    if step.phase_profile.lower() != "sinusoidal":
+        raise ValueError(f"unsupported phase profile: {step.phase_profile}")
+    if step.phase_period_m is None or step.phase_period_m <= 0.0:
+        raise ValueError("sinusoidal phase mask requires positive phase_period_m")
+    if abs(step.phase_amplitude_rad) > math.pi:
+        raise ValueError("phase_amplitude_rad must lie within [-pi, pi]")
+    if step.axis.lower() == "x":
+        coordinate = grid.X - step.center_m[1]
+    elif step.axis.lower() == "y":
+        coordinate = grid.Y - step.center_m[0]
+    else:
+        raise ValueError("phase-mask axis must be 'x' or 'y'")
+    return step.phase_amplitude_rad * np.sin(
+        2.0 * math.pi * coordinate / step.phase_period_m
+    )
+
+
+def _second_moment_waist(
+    field: ComplexArray,
+    grid: OpticalGrid,
+) -> tuple[float, float]:
+    intensity = np.abs(field) ** 2
+    power = field_power(field, grid)
+    mean_y = float(np.sum(intensity * grid.Y) * grid.sample_area / power)
+    mean_x = float(np.sum(intensity * grid.X) * grid.sample_area / power)
+    variance_y = float(
+        np.sum(intensity * (grid.Y - mean_y) ** 2) * grid.sample_area / power
+    )
+    variance_x = float(
+        np.sum(intensity * (grid.X - mean_x) ** 2) * grid.sample_area / power
+    )
+    return 2.0 * math.sqrt(variance_y), 2.0 * math.sqrt(variance_x)

--- a/tests/test_wave_cli.py
+++ b/tests/test_wave_cli.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.cli import main as quantum_main
+from quantum_dynamics_lab.wave_cli import main as wave_main
+from quantum_dynamics_lab.wave_config import load_wave_config
+from quantum_dynamics_lab.wave_experiments import run_wave_propagation
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+
+
+def test_committed_gaussian_lens_config_reaches_predicted_focus(tmp_path: Path) -> None:
+    config_path = REPOSITORY_ROOT / "examples" / "gaussian_lens.toml"
+    config = load_wave_config(config_path)
+    run = run_wave_propagation(config)
+    expected_waist = (
+        config.grid.wavelength_m
+        * config.steps[0].focal_length_m
+        / (math.pi * config.source.waist_m)
+    )
+
+    assert run.metrics["output_second_moment_waist_m"][1] == pytest.approx(
+        expected_waist,
+        rel=0.01,
+    )
+    assert wave_main(["propagate", str(config_path), "--out", str(tmp_path)]) == 0
+    assert (tmp_path / "wave_run.npz").exists()
+    metrics = json.loads((tmp_path / "metrics.json").read_text(encoding="utf-8"))
+    resolved = json.loads(
+        (tmp_path / "resolved_config.json").read_text(encoding="utf-8")
+    )
+    assert metrics["name"] == "gaussian_lens_focus"
+    assert metrics["input_power"] == pytest.approx(1.0, abs=1e-13)
+    assert metrics["final_power"] == pytest.approx(1.0, abs=1e-13)
+    assert [stage["kind"] for stage in metrics["stages"]] == ["lens", "propagate"]
+    assert resolved["grid"]["wavelength_m"] == config.grid.wavelength_m
+    with np.load(tmp_path / "wave_run.npz") as archive:
+        assert archive["input_field"].shape == config.grid.shape
+        assert archive["final_field"].shape == config.grid.shape
+        metadata = json.loads(str(archive["metadata"]))
+    assert metadata["git_commit"]
+    assert "git_dirty" in metadata
+
+
+def test_phase_mask_blas_and_arbitrary_array_source(tmp_path: Path) -> None:
+    source = np.ones((32, 48), dtype=np.complex128)
+    np.save(tmp_path / "source.npy", source)
+    config_path = tmp_path / "wave.toml"
+    config_path.write_text(
+        """
+name = "array_blas"
+[grid]
+shape = [32, 48]
+extent_m = [0.003, 0.004]
+wavelength_m = 6.33e-7
+[source]
+kind = "array"
+path = "source.npy"
+[[steps]]
+kind = "phase_mask"
+phase_profile = "sinusoidal"
+phase_amplitude_rad = 0.5
+phase_period_m = 0.0008
+axis = "x"
+[[steps]]
+kind = "circular_aperture"
+radius_m = 0.001
+[[steps]]
+kind = "propagate"
+model = "blas"
+distance_m = 0.02
+""".strip(),
+        encoding="utf-8",
+    )
+
+    run = run_wave_propagation(load_wave_config(config_path))
+
+    assert run.input_field.shape == (32, 48)
+    assert run.metrics["stages"][2]["retained_spectral_power"] <= 1.0
+    assert run.metrics["final_power"] <= run.metrics["input_power"]
+
+
+def test_invalid_step_and_both_cli_help_surfaces(tmp_path: Path) -> None:
+    config_path = tmp_path / "invalid.toml"
+    config_path.write_text(
+        "name='invalid'\n[[steps]]\nkind='propagate'\nmodel='unknown'\ndistance_m=1.0\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="unsupported propagation model"):
+        run_wave_propagation(load_wave_config(config_path))
+    with pytest.raises(SystemExit) as wave_help:
+        wave_main(["--help"])
+    with pytest.raises(SystemExit) as quantum_help:
+        quantum_main(["--help"])
+    assert wave_help.value.code == 0
+    assert quantum_help.value.code == 0


### PR DESCRIPTION
Closes #36

## Change

Adds an optics-specific TOML schema, ordered forward-experiment adapter, provenance-rich field/metric artifacts, and a new `wave-lab propagate CONFIG --out DIR` command. Configs support square/rectangular grids, Gaussian/HG/arbitrary complex sources, lenses, circular/rectangular apertures, bounded sinusoidal phase masks, and Fresnel/BLAS propagation.

The committed `examples/gaussian_lens.toml` focuses a normalized 1064 nm Gaussian through a thin lens and records input/final power, sampling, model stages, total distance, second-moment output waist, and BLAS retained power where applicable.

## Validation and evidence

- `uv run pytest tests/test_wave_cli.py -q` — 3 passed.
- `uv run pytest` — 57 passed.
- The committed lens example reaches its analytic focal waist within 1%.
- Input and final power remain unity within `1e-13` for the lossless example.
- CLI tests round-trip complex fields, metrics, resolved config, git commit/dirty state, Python, NumPy, and package provenance.
- Rectangular grids, arbitrary `.npy` fields, analytic phase masks, apertures, BLAS stages, invalid models, and both help surfaces are covered.
- M1 model references and quantum v0.1 remain green.

## Milestone status

All M1 exit gates are now met: the pure kernel is in use by the quantum adapter, optics analytic/convergence/model-transfer errors are recorded with a trusted regime, and a CLI config propagates a Gaussian through a lens. `ROADMAP.md` marks M1 complete and `AGENTS.md` advances the current priority to M2.

## Compatibility

The `quantum-lab` entrypoint, quantum config/artifact schemas, dashboard, and recorded v0.1 behavior are unchanged.

This is a stacked draft PR targeting the #34 branch.