### PR TITLE
Validate optical objectives and gradients

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,13 @@ direction and milestone gates; it is not a daily task list.
 
 ## Current Priority
 
-**M0 - Pivot foundation** and **M1 - Forward optics v0.2** are complete. The
-next behavioral work is **M2 - Differentiable solver v0.3**: add optional JAX
-execution without replacing NumPy as the correctness reference, establish
-value parity, add array-native objectives, and validate gradients with centered
-directional finite differences. Do not add the optimization engine or more
-dashboard features ahead of those differentiation gates.
+**M0 - Pivot foundation**, **M1 - Forward optics v0.2**, and **M2 -
+Differentiable solver v0.3** are complete. The next behavioral work is **M3 -
+Inverse-design MVP v0.4**: add bounded phase parameterization, regularization
+and quantization constraints, then build deterministic Adam optimization with
+restart, early stopping, checkpoints, and complete provenance. Do not begin the
+robust flagship or dashboard redesign ahead of that reproducible optimization
+gate.
 
 ## Project Invariants
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,7 +49,7 @@ M0 Pivot foundation
 | --- | --- | --- |
 | M0 - Pivot foundation | Complete | Durable context, workflow templates, accepted decisions, corrected framing, and a frozen quantum v0.1 regression baseline |
 | M1 - Forward optics v0.2 | Complete | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
-| M2 - Differentiable solver v0.3 | Planned | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
+| M2 - Differentiable solver v0.3 | Complete | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
 | M3 - Inverse-design MVP v0.4 | Planned | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
 | M4 - Robust flagship v1.0 | Planned | Robust multi-plane mode conversion, held-out perturbation results, cross-model validation, and the new CLI/dashboard identity |
 

--- a/benchmarks/reference/README.md
+++ b/benchmarks/reference/README.md
@@ -49,3 +49,16 @@ The limits are numerical acceptance thresholds for coherent monochromatic
 scalar free-space optics. Their trusted regime is documented in
 `docs/optics-model-validation.md`; they do not establish vector-Maxwell or
 high-index integrated-photonics accuracy.
+
+## Differentiable solver M2
+
+`jax_m2.json` records NumPy/JAX objective parity, centered directional finite-
+difference checks for mode and intensity losses, and a compiled CPU update. It
+uses deterministic seed `20260714` and JAX x64. Regenerate it with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_jax_m2
+```
+
+The gradient tolerances validate the implemented discrete Fresnel computation,
+not the scalar physical model or an optimization result.

--- a/benchmarks/reference/generate_jax_m2.py
+++ b/benchmarks/reference/generate_jax_m2.py
@@ -1,0 +1,185 @@
+"""Regenerate deterministic M2 objective and gradient evidence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import jax
+
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+import numpy as np
+
+from quantum_dynamics_lab.jax_objectives import (
+    intensity_similarity_jax,
+    mode_overlap_jax,
+    mode_power_efficiency_jax,
+)
+from quantum_dynamics_lab.jax_propagation import multiplane_scan_jax
+from quantum_dynamics_lab.objectives import (
+    intensity_similarity,
+    mode_overlap,
+    mode_power_efficiency,
+)
+from quantum_dynamics_lab.optics import (
+    gaussian_mode,
+    hermite_gaussian_mode,
+    make_optical_grid,
+)
+from quantum_dynamics_lab.optics_propagation import fresnel_transfer_function
+
+
+REFERENCE_PATH = Path(__file__).with_name("jax_m2.json")
+SEED = 20260714
+FINITE_DIFFERENCE_STEP = 1.0e-5
+
+
+def _directional_check(
+    loss: Callable[[jax.Array], jax.Array],
+    parameters: jax.Array,
+    direction: jax.Array,
+) -> dict[str, float]:
+    value, gradient = jax.value_and_grad(loss)(parameters)
+    autodiff = jnp.vdot(gradient, direction).real
+    plus = loss(parameters + FINITE_DIFFERENCE_STEP * direction)
+    minus = loss(parameters - FINITE_DIFFERENCE_STEP * direction)
+    finite_difference = (plus - minus) / (2.0 * FINITE_DIFFERENCE_STEP)
+    absolute_error = jnp.abs(autodiff - finite_difference)
+    scale = jnp.maximum(
+        jnp.maximum(jnp.abs(autodiff), jnp.abs(finite_difference)),
+        1.0e-12,
+    )
+    return {
+        "loss": float(value),
+        "autodiff_directional_derivative": float(autodiff),
+        "finite_difference_directional_derivative": float(finite_difference),
+        "absolute_error": float(absolute_error),
+        "relative_error": float(absolute_error / scale),
+    }
+
+
+def generate_metrics() -> dict[str, Any]:
+    grid = make_optical_grid(32, 4.0e-3, 1064.0e-9)
+    source = gaussian_mode(grid, 0.55e-3)
+    target = hermite_gaussian_mode(grid, (1, 0), 0.55e-3)
+    distances = (0.04, 0.05, 0.03)
+    transfers = np.stack(
+        [fresnel_transfer_function(grid, distance) for distance in distances]
+    )
+    rng = np.random.default_rng(SEED)
+    parameters = 0.25 * rng.standard_normal((len(distances), *grid.shape))
+    direction = rng.standard_normal(parameters.shape)
+    direction /= np.linalg.norm(direction)
+
+    source_jax = jnp.asarray(source)
+    target_jax = jnp.asarray(target)
+    transfers_jax = jnp.asarray(transfers)
+    parameters_jax = jnp.asarray(parameters)
+    direction_jax = jnp.asarray(direction)
+
+    def final_field(phase_masks):
+        return multiplane_scan_jax(
+            source_jax,
+            phase_masks,
+            transfers_jax,
+        )[0]
+
+    def mode_loss(phase_masks):
+        return 1.0 - mode_overlap_jax(
+            final_field(phase_masks),
+            target_jax,
+            grid.sample_area,
+        )
+
+    def intensity_loss(phase_masks):
+        return 1.0 - intensity_similarity_jax(
+            final_field(phase_masks),
+            target_jax,
+            grid.sample_area,
+        )
+
+    final = final_field(parameters_jax)
+    final_numpy = np.asarray(final)
+    numpy_values = {
+        "mode_overlap": mode_overlap(final_numpy, target, grid.sample_area),
+        "intensity_similarity": intensity_similarity(
+            final_numpy,
+            target,
+            grid.sample_area,
+        ),
+        "mode_power_efficiency": mode_power_efficiency(
+            final_numpy,
+            target,
+            1.0,
+            grid.sample_area,
+        ),
+    }
+    jax_values = {
+        "mode_overlap": float(mode_overlap_jax(final, target_jax, grid.sample_area)),
+        "intensity_similarity": float(
+            intensity_similarity_jax(final, target_jax, grid.sample_area)
+        ),
+        "mode_power_efficiency": float(
+            mode_power_efficiency_jax(final, target_jax, 1.0, grid.sample_area)
+        ),
+    }
+
+    @jax.jit
+    def compiled_update(phase_masks):
+        value, gradient = jax.value_and_grad(mode_loss)(phase_masks)
+        return phase_masks - 0.05 * gradient, value, jnp.linalg.norm(gradient)
+
+    updated, update_loss, gradient_norm = compiled_update(parameters_jax)
+    updated.block_until_ready()
+    return {
+        "schema_version": 1,
+        "seed": SEED,
+        "configuration": {
+            "grid": 32,
+            "extent_m": 4.0e-3,
+            "wavelength_m": 1064.0e-9,
+            "waist_m": 0.55e-3,
+            "planes": len(distances),
+            "distances_m": list(distances),
+            "finite_difference_step": FINITE_DIFFERENCE_STEP,
+            "jax_platform": jax.default_backend(),
+            "jax_x64": bool(jax.config.x64_enabled),
+        },
+        "metrics": {
+            "objective_value_max_abs_error": max(
+                abs(numpy_values[name] - jax_values[name]) for name in numpy_values
+            ),
+            "mode_gradient": _directional_check(
+                mode_loss,
+                parameters_jax,
+                direction_jax,
+            ),
+            "intensity_gradient": _directional_check(
+                intensity_loss,
+                parameters_jax,
+                direction_jax,
+            ),
+            "compiled_update_loss": float(update_loss),
+            "compiled_update_gradient_norm": float(gradient_norm),
+            "compiled_update_all_finite": bool(np.all(np.isfinite(np.asarray(updated)))),
+        },
+        "declared_limits": {
+            "objective_value_max_abs_error": 1.0e-12,
+            "gradient_absolute_error": 1.0e-9,
+            "gradient_relative_error": 1.0e-6,
+        },
+    }
+
+
+def main() -> None:
+    REFERENCE_PATH.write_text(
+        json.dumps(generate_metrics(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(REFERENCE_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/reference/jax_m2.json
+++ b/benchmarks/reference/jax_m2.json
@@ -1,0 +1,44 @@
+{
+  "schema_version": 1,
+  "seed": 20260714,
+  "configuration": {
+    "grid": 32,
+    "extent_m": 0.004,
+    "wavelength_m": 1.064e-06,
+    "waist_m": 0.00055,
+    "planes": 3,
+    "distances_m": [
+      0.04,
+      0.05,
+      0.03
+    ],
+    "finite_difference_step": 1e-05,
+    "jax_platform": "cpu",
+    "jax_x64": true
+  },
+  "metrics": {
+    "objective_value_max_abs_error": 2.220446049250313e-16,
+    "mode_gradient": {
+      "loss": 0.9998790977600355,
+      "autodiff_directional_derivative": 5.914684986973689e-05,
+      "finite_difference_directional_derivative": 5.914685408114905e-05,
+      "absolute_error": 4.211412163825697e-12,
+      "relative_error": 7.120264009388682e-08
+    },
+    "intensity_gradient": {
+      "loss": 0.4581730315245507,
+      "autodiff_directional_derivative": -0.0043391327250071774,
+      "finite_difference_directional_derivative": -0.004339132708697235,
+      "absolute_error": 1.6309942112158193e-11,
+      "relative_error": 3.758802310461987e-09
+    },
+    "compiled_update_loss": 0.9998790977600355,
+    "compiled_update_gradient_norm": 0.0031515730396352256,
+    "compiled_update_all_finite": true
+  },
+  "declared_limits": {
+    "objective_value_max_abs_error": 1e-12,
+    "gradient_absolute_error": 1e-09,
+    "gradient_relative_error": 1e-06
+  }
+}

--- a/docs/objectives-and-gradients.md
+++ b/docs/objectives-and-gradients.md
@@ -1,0 +1,42 @@
+# Optical Objectives and Gradient Evidence
+
+The objective layer exposes three dimensionless metrics:
+
+- **Mode overlap** is the squared magnitude of the complex inner product divided
+  by input and target powers. It is insensitive to global phase, equals one for
+  identical modes, and equals zero for orthogonal modes.
+- **Intensity similarity** is cosine similarity between sampled intensities. It
+  measures shape agreement without requiring phase agreement.
+- **Mode power efficiency** is power coupled into the declared target mode
+  divided by the incident input power. Unlike normalized overlap, it penalizes
+  loss before the output plane.
+
+For zero-power inputs or targets the metric is undefined and returns NaN. NumPy
+validates matching finite 2D arrays and positive sample area before evaluation.
+JAX uses array-native operations and produces NaN inside compiled code for the
+same undefined cases.
+
+## M2 Gradient Check
+
+`benchmarks/reference/jax_m2.json` records a deterministic three-plane,
+32-by-32 Gaussian-to-HG10 case with seed `20260714`. For both mode-overlap and
+intensity losses, it compares the reverse-mode directional derivative with
+
+```text
+(loss(theta + epsilon*d) - loss(theta - epsilon*d)) / (2*epsilon)
+```
+
+using a normalized deterministic direction and `epsilon = 1e-5` in JAX x64.
+The declared limits are `1e-9` absolute and `1e-6` relative error. The evidence
+also records NumPy/JAX objective parity and executes one JIT-compiled finite
+parameter update on CPU.
+
+Regenerate the evidence after installing the JAX extra:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_jax_m2
+```
+
+This validates derivatives of the implemented discrete Fresnel model. It does
+not validate the scalar physical approximation or establish optimizer
+robustness; those require the separate model-transfer and held-out ladder.

--- a/src/quantum_dynamics_lab/jax_objectives.py
+++ b/src/quantum_dynamics_lab/jax_objectives.py
@@ -1,0 +1,61 @@
+"""Optional JAX-differentiable scalar optical objectives."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import jax.numpy as jnp
+
+
+def mode_overlap_jax(
+    field: Any,
+    target: Any,
+    sample_area: float = 1.0,
+):
+    """JAX form of normalized phase-insensitive complex-mode overlap."""
+
+    values = jnp.asarray(field)
+    target_values = jnp.asarray(target)
+    area = jnp.asarray(sample_area, dtype=values.real.dtype)
+    inner = jnp.vdot(target_values, values) * area
+    field_power = jnp.sum(jnp.abs(values) ** 2) * area
+    target_power = jnp.sum(jnp.abs(target_values) ** 2) * area
+    denominator = field_power * target_power
+    return jnp.where(denominator > 0.0, jnp.abs(inner) ** 2 / denominator, jnp.nan)
+
+
+def intensity_similarity_jax(
+    field: Any,
+    target: Any,
+    sample_area: float = 1.0,
+):
+    """JAX form of normalized intensity cosine similarity."""
+
+    values = jnp.asarray(field)
+    target_values = jnp.asarray(target)
+    area = jnp.asarray(sample_area, dtype=values.real.dtype)
+    intensity = jnp.abs(values) ** 2
+    target_intensity = jnp.abs(target_values) ** 2
+    numerator = jnp.sum(intensity * target_intensity) * area
+    denominator = jnp.sqrt(
+        jnp.sum(intensity**2) * area * jnp.sum(target_intensity**2) * area
+    )
+    return jnp.where(denominator > 0.0, numerator / denominator, jnp.nan)
+
+
+def mode_power_efficiency_jax(
+    field: Any,
+    target: Any,
+    input_power: float,
+    sample_area: float = 1.0,
+):
+    """JAX form of input-referenced target-mode coupling efficiency."""
+
+    values = jnp.asarray(field)
+    target_values = jnp.asarray(target)
+    area = jnp.asarray(sample_area, dtype=values.real.dtype)
+    input_power_value = jnp.asarray(input_power, dtype=values.real.dtype)
+    target_power = jnp.sum(jnp.abs(target_values) ** 2) * area
+    inner = jnp.vdot(target_values, values) * area
+    denominator = target_power * input_power_value
+    return jnp.where(denominator > 0.0, jnp.abs(inner) ** 2 / denominator, jnp.nan)

--- a/src/quantum_dynamics_lab/objectives.py
+++ b/src/quantum_dynamics_lab/objectives.py
@@ -1,0 +1,88 @@
+"""NumPy reference objectives for scalar optical fields."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+
+__all__ = [
+    "intensity_similarity",
+    "mode_overlap",
+    "mode_power_efficiency",
+]
+
+
+def mode_overlap(
+    field: ArrayLike,
+    target: ArrayLike,
+    sample_area: float = 1.0,
+) -> float:
+    """Return normalized phase-insensitive complex-mode overlap in [0, 1]."""
+
+    values, target_values, area = _validated_fields(field, target, sample_area)
+    inner = np.vdot(target_values, values) * area
+    field_power = float(np.sum(np.abs(values) ** 2) * area)
+    target_power = float(np.sum(np.abs(target_values) ** 2) * area)
+    denominator = field_power * target_power
+    if denominator <= 0.0:
+        return float("nan")
+    return float(np.abs(inner) ** 2 / denominator)
+
+
+def intensity_similarity(
+    field: ArrayLike,
+    target: ArrayLike,
+    sample_area: float = 1.0,
+) -> float:
+    """Return cosine similarity of field intensities in [0, 1]."""
+
+    values, target_values, area = _validated_fields(field, target, sample_area)
+    intensity = np.abs(values) ** 2
+    target_intensity = np.abs(target_values) ** 2
+    numerator = float(np.sum(intensity * target_intensity) * area)
+    denominator = math.sqrt(
+        float(np.sum(intensity**2) * area)
+        * float(np.sum(target_intensity**2) * area)
+    )
+    if denominator <= 0.0:
+        return float("nan")
+    return numerator / denominator
+
+
+def mode_power_efficiency(
+    field: ArrayLike,
+    target: ArrayLike,
+    input_power: float,
+    sample_area: float = 1.0,
+) -> float:
+    """Return target-coupled output power divided by declared input power."""
+
+    values, target_values, area = _validated_fields(field, target, sample_area)
+    if not math.isfinite(input_power) or input_power <= 0.0:
+        return float("nan")
+    target_power = float(np.sum(np.abs(target_values) ** 2) * area)
+    if target_power <= 0.0:
+        return float("nan")
+    inner = np.vdot(target_values, values) * area
+    coupled_power = float(np.abs(inner) ** 2 / target_power)
+    return coupled_power / input_power
+
+
+def _validated_fields(
+    field: ArrayLike,
+    target: ArrayLike,
+    sample_area: float,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    values = np.asarray(field, dtype=np.complex128)
+    target_values = np.asarray(target, dtype=np.complex128)
+    if values.ndim != 2 or values.shape != target_values.shape:
+        raise ValueError("field and target must be matching two-dimensional arrays")
+    area = float(sample_area)
+    if not math.isfinite(area) or area <= 0.0:
+        raise ValueError("sample_area must be finite and positive")
+    if not np.all(np.isfinite(values)) or not np.all(np.isfinite(target_values)):
+        raise ValueError("field and target must contain only finite values")
+    return values, target_values, area

--- a/tests/test_jax_gradients.py
+++ b/tests/test_jax_gradients.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+REFERENCE_PATH = REPOSITORY_ROOT / "benchmarks" / "reference" / "jax_m2.json"
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.reference.generate_jax_m2 import generate_metrics
+
+
+def test_jax_objective_parity_gradients_and_compiled_update() -> None:
+    reference = json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+    evidence = generate_metrics()
+    limits = reference["declared_limits"]
+    metrics = evidence["metrics"]
+
+    assert evidence["seed"] == reference["seed"]
+    assert evidence["configuration"] == reference["configuration"]
+    assert metrics["objective_value_max_abs_error"] < limits[
+        "objective_value_max_abs_error"
+    ]
+    for name in ("mode_gradient", "intensity_gradient"):
+        assert abs(metrics[name]["autodiff_directional_derivative"]) > 1e-12
+        assert metrics[name]["absolute_error"] < limits["gradient_absolute_error"]
+        assert metrics[name]["relative_error"] < limits["gradient_relative_error"]
+    assert metrics["compiled_update_all_finite"]
+    assert metrics["compiled_update_gradient_norm"] > 0.0
+    assert jax.default_backend() == "cpu"

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.objectives import (
+    intensity_similarity,
+    mode_overlap,
+    mode_power_efficiency,
+)
+from quantum_dynamics_lab.optics import (
+    gaussian_mode,
+    hermite_gaussian_mode,
+    make_optical_grid,
+)
+
+
+def test_mode_objectives_have_expected_analytic_values() -> None:
+    grid = make_optical_grid(128, 8.0e-3, 1064.0e-9)
+    gaussian = gaussian_mode(grid, 0.6e-3)
+    hg10 = hermite_gaussian_mode(grid, (1, 0), 0.6e-3)
+    mixture = math.sqrt(0.8) * gaussian + math.sqrt(0.2) * hg10
+
+    assert mode_overlap(gaussian, gaussian, grid.sample_area) == pytest.approx(
+        1.0,
+        abs=1e-14,
+    )
+    assert mode_overlap(gaussian, hg10, grid.sample_area) < 1e-28
+    assert mode_overlap(mixture, gaussian, grid.sample_area) == pytest.approx(
+        0.8,
+        abs=1e-13,
+    )
+    assert mode_power_efficiency(
+        mixture,
+        gaussian,
+        1.0,
+        grid.sample_area,
+    ) == pytest.approx(0.8, abs=1e-13)
+
+
+def test_intensity_similarity_and_zero_power_behavior() -> None:
+    field = np.array([[1.0, 2.0], [0.5, 0.25]], dtype=np.complex128)
+    orthogonal_intensity = np.array([[0.0, 0.0], [0.0, 1.0]])
+
+    assert intensity_similarity(field, field) == pytest.approx(1.0, abs=1e-15)
+    assert 0.0 < intensity_similarity(field, orthogonal_intensity) < 1.0
+    assert math.isnan(mode_overlap(np.zeros_like(field), field))
+    assert math.isnan(intensity_similarity(np.zeros_like(field), field))
+    assert math.isnan(mode_power_efficiency(field, field, 0.0))
+
+
+def test_objectives_validate_shape_area_and_finite_values() -> None:
+    with pytest.raises(ValueError, match="matching two-dimensional"):
+        mode_overlap(np.zeros((2, 2)), np.zeros((3, 3)))
+    with pytest.raises(ValueError, match="sample_area"):
+        intensity_similarity(np.ones((2, 2)), np.ones((2, 2)), 0.0)
+    with pytest.raises(ValueError, match="finite"):
+        mode_overlap(np.full((2, 2), np.nan), np.ones((2, 2)))


### PR DESCRIPTION
Closes #40

## Change

Adds NumPy reference and JAX-differentiable implementations of normalized phase-insensitive mode overlap, normalized intensity similarity, and input-referenced target-mode power efficiency. It records deterministic centered directional finite-difference evidence through a three-plane JAX Fresnel scan and runs a JIT-compiled CPU value/gradient update.

Objective normalization, ranges, undefined zero-power behavior, and scientific interpretation are documented. A small reproducible M2 fixture and regeneration module are committed.

## Validation and evidence

- Focused objective/JAX suites — 8 passed.
- `JAX_ENABLE_X64=1 uv run --extra jax --extra ui pytest` — 65 passed.
- NumPy/JAX objective maximum absolute error: `2.2204e-16`.
- Centered finite-difference step: `1e-5`.
- Mode-loss directional absolute/relative errors: `4.2114e-12` / `7.1203e-8`.
- Intensity-loss directional absolute/relative errors: `1.6310e-11` / `3.7588e-9`.
- Declared gradient limits: `1e-9` absolute and `1e-6` relative.
- Compiled CPU update gradient norm: `3.1516e-3`; all outputs finite.
- Analytic identical, orthogonal Gaussian/HG10, and known-mixture objective cases pass.

## Milestone status

All M2 exit gates now pass: x64 value parity, fixed-shape JIT scan, normalized objectives, centered directional gradient validation, a compiled CPU update, and documented optional accelerator behavior. `ROADMAP.md` marks M2 complete and `AGENTS.md` advances current priority to M3.

## Interpretation and compatibility

Gradient evidence validates the implemented discrete Fresnel computation, not the scalar physical approximation or optimizer robustness. NumPy remains the reference, BLAS remains the independent evaluation model, and all quantum/M1/CLI/dashboard regressions remain green.

This is a stacked draft PR targeting the #38 branch.