### PR TITLE
Add bounded phase design constraints

### DIFF
--- a/docs/phase-constraints.md
+++ b/docs/phase-constraints.md
@@ -1,0 +1,24 @@
+# Phase Parameterization and Constraints
+
+Unconstrained real design variables are mapped to phase with a shifted/scaled
+`tanh`, keeping every value inside explicit bounds. Optional periodic five-point
+smoothing is applied to the design variables before the bounded map, so the
+result remains bounded while high-frequency roughness is reduced.
+
+Wrapped isotropic total variation uses nearest-neighbor phase differences mapped
+through `atan2(sin(delta), cos(delta))`. It therefore measures physical phase
+jumps modulo 2π and is invariant when integer phase cycles are added to samples.
+It is a regularization term, not a hard fabrication guarantee.
+
+Optional hard quantization maps phase to equally spaced levels in the half-open
+interval `[phase_min, phase_max)`. Evaluation uses the hard values. Optimization
+may use a straight-through estimator: its forward value is exactly quantized,
+while its local backward derivative is the identity. Reports must disclose when
+this biased estimator is used and must evaluate the saved design with hard
+quantization.
+
+NumPy supplies the reference functions in `constraints.py`; JAX supplies the
+JIT-compatible differentiable path in `jax_constraints.py`. Focused tests cover
+array parity, exact levels, bounds, roughness reduction, wrapped-TV invariance,
+straight-through gradients, and a centered directional derivative through the
+composed constraint path.

--- a/src/quantum_dynamics_lab/constraints.py
+++ b/src/quantum_dynamics_lab/constraints.py
@@ -1,0 +1,127 @@
+"""NumPy reference phase parameterization and fabrication constraints."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+
+FloatArray = NDArray[np.float64]
+
+__all__ = [
+    "bounded_phase",
+    "parameterize_phase",
+    "phase_total_variation",
+    "quantize_phase",
+    "smooth_periodic",
+]
+
+
+def bounded_phase(
+    parameters: ArrayLike,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+) -> FloatArray:
+    """Map unconstrained real variables smoothly inside phase bounds."""
+
+    lower, upper = _validate_bounds(bounds)
+    values = _finite_array(parameters)
+    midpoint = 0.5 * (lower + upper)
+    half_range = 0.5 * (upper - lower)
+    return np.asarray(midpoint + half_range * np.tanh(values), dtype=np.float64)
+
+
+def smooth_periodic(values: ArrayLike, passes: int = 1) -> FloatArray:
+    """Apply repeated differentiable five-point periodic smoothing."""
+
+    passes = _validate_passes(passes)
+    smoothed = _finite_array(values).copy()
+    for _ in range(passes):
+        smoothed = (
+            0.5 * smoothed
+            + 0.125 * np.roll(smoothed, 1, axis=-2)
+            + 0.125 * np.roll(smoothed, -1, axis=-2)
+            + 0.125 * np.roll(smoothed, 1, axis=-1)
+            + 0.125 * np.roll(smoothed, -1, axis=-1)
+        )
+    return np.asarray(smoothed, dtype=np.float64)
+
+
+def phase_total_variation(phase: ArrayLike, epsilon: float = 1.0e-8) -> float:
+    """Return mean isotropic TV using wrapped periodic phase differences."""
+
+    values = _finite_array(phase)
+    epsilon = float(epsilon)
+    if not math.isfinite(epsilon) or epsilon <= 0.0:
+        raise ValueError("epsilon must be finite and positive")
+    dx = _wrapped_difference(np.roll(values, -1, axis=-1) - values)
+    dy = _wrapped_difference(np.roll(values, -1, axis=-2) - values)
+    return float(np.mean(np.sqrt(dx**2 + dy**2 + epsilon**2) - epsilon))
+
+
+def quantize_phase(
+    phase: ArrayLike,
+    levels: int,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+) -> FloatArray:
+    """Hard-quantize periodic phase into equally spaced levels in [min, max)."""
+
+    levels = _validate_levels(levels)
+    lower, upper = _validate_bounds(bounds)
+    values = _finite_array(phase)
+    span = upper - lower
+    step = span / levels
+    wrapped = np.mod(values - lower, span)
+    indices = np.mod(np.floor(wrapped / step + 0.5), levels)
+    return np.asarray(lower + indices * step, dtype=np.float64)
+
+
+def parameterize_phase(
+    parameters: ArrayLike,
+    *,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+    smoothing_passes: int = 0,
+    quantization_levels: int | None = None,
+) -> FloatArray:
+    """Compose smoothing, bounded mapping, and optional hard quantization."""
+
+    values = smooth_periodic(parameters, smoothing_passes)
+    phase = bounded_phase(values, bounds)
+    if quantization_levels is not None:
+        phase = quantize_phase(phase, quantization_levels, bounds)
+    return phase
+
+
+def _wrapped_difference(values: FloatArray) -> FloatArray:
+    return np.arctan2(np.sin(values), np.cos(values))
+
+
+def _finite_array(values: ArrayLike) -> FloatArray:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim < 2:
+        raise ValueError("phase arrays must have at least two dimensions")
+    if not np.all(np.isfinite(array)):
+        raise ValueError("phase arrays must contain only finite values")
+    return array
+
+
+def _validate_bounds(bounds: tuple[float, float]) -> tuple[float, float]:
+    if len(bounds) != 2:
+        raise ValueError("bounds must contain two values")
+    lower, upper = float(bounds[0]), float(bounds[1])
+    if not math.isfinite(lower) or not math.isfinite(upper) or lower >= upper:
+        raise ValueError("bounds must be finite and strictly increasing")
+    return lower, upper
+
+
+def _validate_passes(passes: int) -> int:
+    if isinstance(passes, bool) or not isinstance(passes, int) or passes < 0:
+        raise ValueError("smoothing passes must be a nonnegative integer")
+    return passes
+
+
+def _validate_levels(levels: int) -> int:
+    if isinstance(levels, bool) or not isinstance(levels, int) or levels < 2:
+        raise ValueError("quantization levels must be an integer of at least two")
+    return levels

--- a/src/quantum_dynamics_lab/jax_constraints.py
+++ b/src/quantum_dynamics_lab/jax_constraints.py
@@ -1,0 +1,106 @@
+"""Optional JAX phase parameterization and fabrication constraints."""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+
+def bounded_phase_jax(
+    parameters: Any,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+):
+    lower, upper = _validate_bounds(bounds)
+    values = jnp.asarray(parameters)
+    midpoint = 0.5 * (lower + upper)
+    half_range = 0.5 * (upper - lower)
+    return midpoint + half_range * jnp.tanh(values)
+
+
+def smooth_periodic_jax(values: Any, passes: int = 1):
+    passes = _validate_passes(passes)
+    smoothed = jnp.asarray(values)
+    for _ in range(passes):
+        smoothed = (
+            0.5 * smoothed
+            + 0.125 * jnp.roll(smoothed, 1, axis=-2)
+            + 0.125 * jnp.roll(smoothed, -1, axis=-2)
+            + 0.125 * jnp.roll(smoothed, 1, axis=-1)
+            + 0.125 * jnp.roll(smoothed, -1, axis=-1)
+        )
+    return smoothed
+
+
+def phase_total_variation_jax(phase: Any, epsilon: float = 1.0e-8):
+    values = jnp.asarray(phase)
+    dx = _wrapped_difference_jax(jnp.roll(values, -1, axis=-1) - values)
+    dy = _wrapped_difference_jax(jnp.roll(values, -1, axis=-2) - values)
+    return jnp.mean(jnp.sqrt(dx**2 + dy**2 + epsilon**2) - epsilon)
+
+
+def quantize_phase_jax(
+    phase: Any,
+    levels: int,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+    *,
+    straight_through: bool = False,
+):
+    levels = _validate_levels(levels)
+    lower, upper = _validate_bounds(bounds)
+    values = jnp.asarray(phase)
+    span = upper - lower
+    step = span / levels
+    wrapped = jnp.mod(values - lower, span)
+    indices = jnp.mod(jnp.floor(wrapped / step + 0.5), levels)
+    quantized = lower + indices * step
+    if straight_through:
+        return values + jax.lax.stop_gradient(quantized - values)
+    return quantized
+
+
+def parameterize_phase_jax(
+    parameters: Any,
+    *,
+    bounds: tuple[float, float] = (-math.pi, math.pi),
+    smoothing_passes: int = 0,
+    quantization_levels: int | None = None,
+    straight_through: bool = True,
+):
+    values = smooth_periodic_jax(parameters, smoothing_passes)
+    phase = bounded_phase_jax(values, bounds)
+    if quantization_levels is not None:
+        phase = quantize_phase_jax(
+            phase,
+            quantization_levels,
+            bounds,
+            straight_through=straight_through,
+        )
+    return phase
+
+
+def _wrapped_difference_jax(values):
+    return jnp.arctan2(jnp.sin(values), jnp.cos(values))
+
+
+def _validate_bounds(bounds: tuple[float, float]) -> tuple[float, float]:
+    if len(bounds) != 2:
+        raise ValueError("bounds must contain two values")
+    lower, upper = float(bounds[0]), float(bounds[1])
+    if not math.isfinite(lower) or not math.isfinite(upper) or lower >= upper:
+        raise ValueError("bounds must be finite and strictly increasing")
+    return lower, upper
+
+
+def _validate_passes(passes: int) -> int:
+    if isinstance(passes, bool) or not isinstance(passes, int) or passes < 0:
+        raise ValueError("smoothing passes must be a nonnegative integer")
+    return passes
+
+
+def _validate_levels(levels: int) -> int:
+    if isinstance(levels, bool) or not isinstance(levels, int) or levels < 2:
+        raise ValueError("quantization levels must be an integer of at least two")
+    return levels

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from quantum_dynamics_lab.constraints import (
+    bounded_phase,
+    parameterize_phase,
+    phase_total_variation,
+    quantize_phase,
+    smooth_periodic,
+)
+
+
+def test_bounded_phase_and_composition_stay_inside_limits() -> None:
+    parameters = np.linspace(-20.0, 20.0, 256).reshape(16, 16)
+    bounds = (-0.25 * math.pi, 0.75 * math.pi)
+
+    phase = bounded_phase(parameters, bounds)
+    composed = parameterize_phase(parameters, bounds=bounds, smoothing_passes=2)
+
+    for values in (phase, composed):
+        assert np.min(values) >= bounds[0]
+        assert np.max(values) <= bounds[1]
+        assert np.all(np.isfinite(values))
+
+
+def test_smoothing_reduces_deterministic_total_variation() -> None:
+    checkerboard = (-1.0) ** sum(np.indices((32, 32)))
+    phase = bounded_phase(checkerboard)
+    smoothed = bounded_phase(smooth_periodic(checkerboard, passes=3))
+
+    assert phase_total_variation(smoothed) < 0.1 * phase_total_variation(phase)
+
+
+def test_wrapped_tv_is_invariant_to_full_phase_cycles() -> None:
+    rng = np.random.default_rng(42)
+    phase = rng.uniform(-math.pi, math.pi, (16, 16))
+    cycles = 2.0 * math.pi * rng.integers(-3, 4, phase.shape)
+
+    assert phase_total_variation(phase + cycles) == pytest.approx(
+        phase_total_variation(phase),
+        abs=2e-15,
+    )
+
+
+def test_quantization_has_exact_requested_periodic_levels() -> None:
+    phase = np.linspace(-math.pi, math.pi, 4096, endpoint=False).reshape(64, 64)
+    quantized = quantize_phase(phase, 8)
+    expected = -math.pi + np.arange(8) * (2.0 * math.pi / 8)
+
+    np.testing.assert_allclose(np.unique(quantized), expected, atol=1e-15)
+    np.testing.assert_allclose(
+        parameterize_phase(phase, quantization_levels=8),
+        quantize_phase(bounded_phase(phase), 8),
+        atol=0.0,
+    )
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: bounded_phase(np.ones((2, 2)), (1.0, 1.0)),
+        lambda: smooth_periodic(np.ones((2, 2)), -1),
+        lambda: quantize_phase(np.ones((2, 2)), 1),
+    ],
+)
+def test_invalid_constraint_configuration_fails(call) -> None:
+    with pytest.raises(ValueError):
+        call()

--- a/tests/test_jax_constraints.py
+++ b/tests/test_jax_constraints.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+import jax.numpy as jnp
+
+from quantum_dynamics_lab.constraints import parameterize_phase, phase_total_variation
+from quantum_dynamics_lab.jax_constraints import (
+    parameterize_phase_jax,
+    phase_total_variation_jax,
+    quantize_phase_jax,
+)
+
+
+def test_jax_constraint_composition_matches_numpy_and_jits() -> None:
+    rng = np.random.default_rng(20260714)
+    parameters = rng.standard_normal((3, 24, 32))
+    expected = parameterize_phase(
+        parameters,
+        bounds=(-0.75 * math.pi, 0.9 * math.pi),
+        smoothing_passes=2,
+        quantization_levels=16,
+    )
+    compiled = jax.jit(
+        lambda values: parameterize_phase_jax(
+            values,
+            bounds=(-0.75 * math.pi, 0.9 * math.pi),
+            smoothing_passes=2,
+            quantization_levels=16,
+            straight_through=False,
+        )
+    )
+    actual = compiled(jnp.asarray(parameters))
+
+    np.testing.assert_allclose(np.asarray(actual), expected, atol=2e-15, rtol=0.0)
+
+
+def test_straight_through_quantization_has_hard_value_and_useful_gradient() -> None:
+    parameters = jnp.linspace(-1.0, 1.0, 64).reshape(8, 8)
+    hard = quantize_phase_jax(parameters, 8, straight_through=False)
+    straight_through = quantize_phase_jax(parameters, 8, straight_through=True)
+    gradient = jax.grad(
+        lambda values: jnp.sum(
+            quantize_phase_jax(values, 8, straight_through=True)
+        )
+    )(parameters)
+
+    np.testing.assert_array_equal(np.asarray(straight_through), np.asarray(hard))
+    np.testing.assert_allclose(np.asarray(gradient), 1.0, atol=0.0, rtol=0.0)
+
+
+def test_constraint_directional_derivative_matches_centered_difference() -> None:
+    rng = np.random.default_rng(4242)
+    parameters = jnp.asarray(rng.standard_normal((2, 16, 16)))
+    direction_values = rng.standard_normal(parameters.shape)
+    direction_values /= np.linalg.norm(direction_values)
+    direction = jnp.asarray(direction_values)
+
+    def loss(values):
+        phase = parameterize_phase_jax(values, smoothing_passes=2)
+        return jnp.mean(jnp.sin(phase)) + 0.03 * phase_total_variation_jax(phase)
+
+    gradient = jax.grad(loss)(parameters)
+    autodiff = float(jnp.vdot(gradient, direction))
+    epsilon = 1.0e-5
+    finite_difference = float(
+        (loss(parameters + epsilon * direction) - loss(parameters - epsilon * direction))
+        / (2.0 * epsilon)
+    )
+    relative_error = abs(autodiff - finite_difference) / max(
+        abs(autodiff),
+        abs(finite_difference),
+        1e-12,
+    )
+
+    assert abs(autodiff) > 1e-8
+    assert relative_error < 1e-6
+    phase = np.asarray(parameterize_phase_jax(parameters, smoothing_passes=2))
+    assert float(phase_total_variation_jax(phase)) == pytest.approx(
+        phase_total_variation(phase),
+        abs=2e-15,
+    )


### PR DESCRIPTION
Closes #42

## Change

Adds NumPy reference and JAX-native constrained phase parameterization: shifted/scaled tanh bounds, repeated periodic five-point smoothing, wrapped isotropic total variation, exact periodic phase quantization, and an optional straight-through estimator for optimization.

The composed JAX path is JIT-compatible and never converts traced values through NumPy. Documentation distinguishes hard evaluation from the biased straight-through training estimator.

## Validation and evidence

- Focused constraint suites — 10 passed.
- `JAX_ENABLE_X64=1 uv run --extra jax --extra ui pytest` — 75 passed.
- NumPy/JAX composed hard-quantized phase max error: `2.2204e-16`.
- Deterministic checkerboard TV: `2.1184` before smoothing and zero after three passes.
- Wrapped TV is invariant to per-pixel integer multiples of 2π at `2e-15` tolerance.
- Eight-level hard quantization emits exactly the eight expected periodic levels.
- Straight-through forward values equal hard quantization exactly; local gradients are finite and unity.
- Centered constraint-path directional derivative relative error: `3.3933e-10` with `epsilon=1e-5`.
- Invalid bounds, passes, and levels fail clearly.

## Interpretation and compatibility

TV is a regularizer, not a fabrication guarantee. Straight-through gradients are explicitly disclosed as biased, and saved designs must be evaluated with hard quantization. All M2/M1/quantum/CLI/dashboard regressions remain green.

This is a stacked draft PR targeting the #40 branch.