### PR TITLE
Build restartable inverse-design runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,13 @@ direction and milestone gates; it is not a daily task list.
 
 ## Current Priority
 
-**M0 - Pivot foundation**, **M1 - Forward optics v0.2**, and **M2 -
-Differentiable solver v0.3** are complete. The next behavioral work is **M3 -
-Inverse-design MVP v0.4**: add bounded phase parameterization, regularization
-and quantization constraints, then build deterministic Adam optimization with
-restart, early stopping, checkpoints, and complete provenance. Do not begin the
-robust flagship or dashboard redesign ahead of that reproducible optimization
-gate.
+**M0 - Pivot foundation**, **M1 - Forward optics v0.2**, **M2 - Differentiable
+solver v0.3**, and **M3 - Inverse-design MVP v0.4** are complete. The current
+priority is **M4 - Robust flagship v1.0**: run the declared Gaussian-to-HG10
+baseline ladder, separate optimization and held-out perturbations, validate
+grid/padding/aperture/step convergence, and report Fresnel-to-band-limited-
+angular-spectrum transfer before completing the CLI/dashboard/documentation
+identity. Do not claim robustness from the optimization ensemble alone.
 
 ## Project Invariants
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,7 @@ M0 Pivot foundation
 | M0 - Pivot foundation | Complete | Durable context, workflow templates, accepted decisions, corrected framing, and a frozen quantum v0.1 regression baseline |
 | M1 - Forward optics v0.2 | Complete | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
 | M2 - Differentiable solver v0.3 | Complete | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
-| M3 - Inverse-design MVP v0.4 | Planned | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
+| M3 - Inverse-design MVP v0.4 | Complete | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
 | M4 - Robust flagship v1.0 | Planned | Robust multi-plane mode conversion, held-out perturbation results, cross-model validation, and the new CLI/dashboard identity |
 
 ### M0 - Pivot Foundation

--- a/docs/inverse-design-runner.md
+++ b/docs/inverse-design-runner.md
@@ -1,0 +1,36 @@
+# M3 Inverse-Design Runner
+
+The M3 runner optimizes one phase mask per declared propagation distance using
+JAX x64 Fresnel propagation and deterministic Adam. Unconstrained variables are
+smoothed, bounded, and optionally straight-through quantized during training;
+saved and reported designs always use hard quantization. The loss can combine
+mode-overlap, intensity-similarity, and wrapped-TV terms.
+
+Run the committed deterministic smoke experiment with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax wave-lab optimize \
+  examples/inverse_design_smoke.toml --out runs/inverse-design-smoke
+```
+
+Resume an interrupted run without changing its config:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax wave-lab optimize \
+  examples/inverse_design_smoke.toml --out runs/inverse-design-smoke \
+  --resume runs/inverse-design-smoke/checkpoint.npz
+```
+
+The checkpoint contains parameters, both Adam moments, iteration, best design,
+early-stop state, and full history. A SHA-256 fingerprint of the complete
+resolved config prevents accidental restart under changed experiment semantics.
+
+Each run writes `history.json`, `resolved_config.json`, `environment.json`,
+`fields.npz`, `metrics.json`, `best_design.npz`, `checkpoint.npz`, and
+`report.md`. Provenance includes git commit/dirty state, dependency versions,
+backend/device, x64 status, and seed. The report exposes objectives, constraints,
+and the committed M2 gradient evidence.
+
+The deterministic CI smoke establishes objective improvement and restart
+equivalence for the discrete optimizer. It does not establish robustness or
+physical transfer; those are M4 held-out and independent-model requirements.

--- a/examples/inverse_design_smoke.toml
+++ b/examples/inverse_design_smoke.toml
@@ -1,0 +1,34 @@
+name = "inverse_design_smoke"
+seed = 20260714
+
+[grid]
+shape = 24
+extent_m = 0.004
+wavelength_m = 1.064e-6
+
+[input_mode]
+kind = "gaussian"
+waist_m = 0.00055
+
+[target_mode]
+kind = "hermite_gaussian"
+order = [1, 0]
+waist_m = 0.00055
+
+[design]
+plane_distances_m = [0.04, 0.05, 0.03]
+initial_scale = 0.2
+phase_bounds_rad = [-3.141592653589793, 3.141592653589793]
+smoothing_passes = 1
+total_variation_weight = 0.0001
+
+[objective]
+mode_overlap_weight = 1.0
+intensity_weight = 0.05
+
+[optimizer]
+iterations = 30
+learning_rate = 0.08
+checkpoint_interval = 5
+early_stopping_patience = 15
+min_delta = 1e-8

--- a/src/quantum_dynamics_lab/design_config.py
+++ b/src/quantum_dynamics_lab/design_config.py
@@ -1,0 +1,162 @@
+"""Typed configuration for constrained scalar-wave inverse design."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+import math
+import tomllib
+
+from .wave_config import OpticalGridConfig
+
+
+@dataclass(frozen=True)
+class DesignModeConfig:
+    kind: str = "gaussian"
+    waist_m: float = 0.5e-3
+    order: tuple[int, int] = (0, 0)
+    center_m: tuple[float, float] = (0.0, 0.0)
+
+
+@dataclass(frozen=True)
+class PhaseDesignConfig:
+    plane_distances_m: tuple[float, ...] = (0.05,)
+    initial_scale: float = 0.1
+    phase_bounds_rad: tuple[float, float] = (-math.pi, math.pi)
+    smoothing_passes: int = 1
+    total_variation_weight: float = 0.0
+    quantization_levels: int | None = None
+
+
+@dataclass(frozen=True)
+class ObjectiveConfig:
+    mode_overlap_weight: float = 1.0
+    intensity_weight: float = 0.0
+
+
+@dataclass(frozen=True)
+class AdamConfig:
+    iterations: int = 40
+    learning_rate: float = 0.05
+    beta1: float = 0.9
+    beta2: float = 0.999
+    epsilon: float = 1.0e-8
+    checkpoint_interval: int = 10
+    early_stopping_patience: int = 20
+    min_delta: float = 1.0e-8
+
+
+@dataclass(frozen=True)
+class InverseDesignConfig:
+    name: str = "inverse_design"
+    seed: int = 0
+    grid: OpticalGridConfig = field(default_factory=OpticalGridConfig)
+    input_mode: DesignModeConfig = field(default_factory=DesignModeConfig)
+    target_mode: DesignModeConfig = field(
+        default_factory=lambda: DesignModeConfig(kind="hermite_gaussian", order=(1, 0))
+    )
+    design: PhaseDesignConfig = field(default_factory=PhaseDesignConfig)
+    objective: ObjectiveConfig = field(default_factory=ObjectiveConfig)
+    optimizer: AdamConfig = field(default_factory=AdamConfig)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_inverse_design_config(path: str | Path) -> InverseDesignConfig:
+    path = Path(path)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    grid_data = _table(data, "grid")
+    input_data = _table(data, "input_mode")
+    target_data = _table(data, "target_mode")
+    design_data = _table(data, "design")
+    objective_data = _table(data, "objective")
+    optimizer_data = _table(data, "optimizer")
+    quantization_levels = design_data.get("quantization_levels")
+    return InverseDesignConfig(
+        name=str(data.get("name", path.stem)),
+        seed=int(data.get("seed", 0)),
+        grid=OpticalGridConfig(
+            shape=_int_pair(grid_data.get("shape", 128), "grid.shape"),
+            extent_m=_float_pair(
+                grid_data.get("extent_m", 6.0e-3),
+                "grid.extent_m",
+            ),
+            wavelength_m=float(grid_data.get("wavelength_m", 1064.0e-9)),
+        ),
+        input_mode=_mode(input_data, "gaussian"),
+        target_mode=_mode(target_data, "hermite_gaussian", (1, 0)),
+        design=PhaseDesignConfig(
+            plane_distances_m=tuple(
+                float(value)
+                for value in design_data.get("plane_distances_m", [0.05])
+            ),
+            initial_scale=float(design_data.get("initial_scale", 0.1)),
+            phase_bounds_rad=_float_pair(
+                design_data.get("phase_bounds_rad", (-math.pi, math.pi)),
+                "design.phase_bounds_rad",
+            ),
+            smoothing_passes=int(design_data.get("smoothing_passes", 1)),
+            total_variation_weight=float(
+                design_data.get("total_variation_weight", 0.0)
+            ),
+            quantization_levels=(
+                None if quantization_levels is None else int(quantization_levels)
+            ),
+        ),
+        objective=ObjectiveConfig(
+            mode_overlap_weight=float(
+                objective_data.get("mode_overlap_weight", 1.0)
+            ),
+            intensity_weight=float(objective_data.get("intensity_weight", 0.0)),
+        ),
+        optimizer=AdamConfig(
+            iterations=int(optimizer_data.get("iterations", 40)),
+            learning_rate=float(optimizer_data.get("learning_rate", 0.05)),
+            beta1=float(optimizer_data.get("beta1", 0.9)),
+            beta2=float(optimizer_data.get("beta2", 0.999)),
+            epsilon=float(optimizer_data.get("epsilon", 1.0e-8)),
+            checkpoint_interval=int(
+                optimizer_data.get("checkpoint_interval", 10)
+            ),
+            early_stopping_patience=int(
+                optimizer_data.get("early_stopping_patience", 20)
+            ),
+            min_delta=float(optimizer_data.get("min_delta", 1.0e-8)),
+        ),
+    )
+
+
+def _mode(
+    data: dict[str, Any],
+    default_kind: str,
+    default_order: tuple[int, int] = (0, 0),
+) -> DesignModeConfig:
+    return DesignModeConfig(
+        kind=str(data.get("kind", default_kind)),
+        waist_m=float(data.get("waist_m", 0.5e-3)),
+        order=_int_pair(data.get("order", default_order), "mode.order"),
+        center_m=_float_pair(data.get("center_m", (0.0, 0.0)), "mode.center_m"),
+    )
+
+
+def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data.get(name, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"[{name}] must be a TOML table")
+    return value
+
+
+def _int_pair(value: Any, name: str) -> tuple[int, int]:
+    values = (value, value) if isinstance(value, int) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be an integer or two-item array")
+    return int(values[0]), int(values[1])
+
+
+def _float_pair(value: Any, name: str) -> tuple[float, float]:
+    values = (value, value) if isinstance(value, (int, float)) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be a number or two-item array")
+    return float(values[0]), float(values[1])

--- a/src/quantum_dynamics_lab/optimization.py
+++ b/src/quantum_dynamics_lab/optimization.py
@@ -1,0 +1,581 @@
+"""Deterministic restartable Adam runner for constrained inverse design."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from hashlib import sha256
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+import json
+import platform
+import subprocess
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from . import __version__
+from .design_config import DesignModeConfig, InverseDesignConfig
+from .jax_constraints import parameterize_phase_jax, phase_total_variation_jax
+from .jax_objectives import (
+    intensity_similarity_jax,
+    mode_overlap_jax,
+    mode_power_efficiency_jax,
+)
+from .jax_propagation import multiplane_scan_jax
+from .optics import gaussian_mode, hermite_gaussian_mode, make_optical_grid
+from .optics_propagation import fresnel_transfer_function
+
+
+@dataclass
+class _OptimizationState:
+    parameters: Any
+    first_moment: Any
+    second_moment: Any
+    best_parameters: Any
+    step: int
+    best_loss: float
+    best_iteration: int
+    patience_loss: float
+    stall_count: int
+    history: list[dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class OptimizationResult:
+    out_dir: Path
+    status: str
+    metrics: dict[str, Any]
+
+
+def run_inverse_design(
+    config: InverseDesignConfig,
+    out_dir: str | Path,
+    *,
+    resume: str | Path | None = None,
+    max_steps: int | None = None,
+) -> OptimizationResult:
+    """Run or resume deterministic constrained Adam optimization."""
+
+    jax.config.update("jax_enable_x64", True)
+    _validate_config(config)
+    out_dir = Path(out_dir)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    fingerprint = _config_fingerprint(config)
+    grid = make_optical_grid(
+        config.grid.shape,
+        config.grid.extent_m,
+        config.grid.wavelength_m,
+    )
+    source = _make_mode(config.input_mode, grid)
+    target = _make_mode(config.target_mode, grid)
+    transfers = np.stack(
+        [
+            fresnel_transfer_function(grid, distance)
+            for distance in config.design.plane_distances_m
+        ]
+    )
+    source_jax = jnp.asarray(source)
+    target_jax = jnp.asarray(target)
+    transfers_jax = jnp.asarray(transfers)
+    area = grid.sample_area
+
+    def evaluate(parameters, *, straight_through: bool):
+        phases = parameterize_phase_jax(
+            parameters,
+            bounds=config.design.phase_bounds_rad,
+            smoothing_passes=config.design.smoothing_passes,
+            quantization_levels=config.design.quantization_levels,
+            straight_through=straight_through,
+        )
+        final_field, _ = multiplane_scan_jax(source_jax, phases, transfers_jax)
+        overlap = mode_overlap_jax(final_field, target_jax, area)
+        intensity = intensity_similarity_jax(final_field, target_jax, area)
+        efficiency = mode_power_efficiency_jax(final_field, target_jax, 1.0, area)
+        total_variation = jnp.mean(
+            jax.vmap(phase_total_variation_jax)(phases)
+        )
+        loss = (
+            config.objective.mode_overlap_weight * (1.0 - overlap)
+            + config.objective.intensity_weight * (1.0 - intensity)
+            + config.design.total_variation_weight * total_variation
+        )
+        auxiliary = jnp.asarray(
+            [overlap, intensity, efficiency, total_variation],
+            dtype=final_field.real.dtype,
+        )
+        return loss, auxiliary
+
+    def training_objective(parameters):
+        return evaluate(parameters, straight_through=True)
+
+    def hard_objective(parameters):
+        return evaluate(parameters, straight_through=False)
+
+    @jax.jit
+    def adam_step(parameters, first_moment, second_moment, step):
+        (_, _), gradient = jax.value_and_grad(
+            training_objective,
+            has_aux=True,
+        )(parameters)
+        first_moment = (
+            config.optimizer.beta1 * first_moment
+            + (1.0 - config.optimizer.beta1) * gradient
+        )
+        second_moment = (
+            config.optimizer.beta2 * second_moment
+            + (1.0 - config.optimizer.beta2) * gradient**2
+        )
+        first_unbiased = first_moment / (1.0 - config.optimizer.beta1**step)
+        second_unbiased = second_moment / (1.0 - config.optimizer.beta2**step)
+        parameters = parameters - config.optimizer.learning_rate * first_unbiased / (
+            jnp.sqrt(second_unbiased) + config.optimizer.epsilon
+        )
+        training_loss, _ = training_objective(parameters)
+        return (
+            parameters,
+            first_moment,
+            second_moment,
+            training_loss,
+            jnp.linalg.norm(gradient),
+        )
+
+    hard_evaluate = jax.jit(hard_objective)
+
+    def fields(parameters):
+        phases = parameterize_phase_jax(
+            parameters,
+            bounds=config.design.phase_bounds_rad,
+            smoothing_passes=config.design.smoothing_passes,
+            quantization_levels=config.design.quantization_levels,
+            straight_through=False,
+        )
+        final_field, history = multiplane_scan_jax(
+            source_jax,
+            phases,
+            transfers_jax,
+        )
+        return phases, final_field, history
+
+    compiled_fields = jax.jit(fields)
+    if resume is None:
+        rng = np.random.default_rng(config.seed)
+        parameters = jnp.asarray(
+            config.design.initial_scale
+            * rng.standard_normal((len(transfers), *grid.shape)),
+            dtype=jnp.float64,
+        )
+        initial_loss, initial_aux = hard_evaluate(parameters)
+        initial_record = _history_record(
+            0,
+            float(initial_loss),
+            initial_aux,
+            float(initial_loss),
+            0.0,
+        )
+        state = _OptimizationState(
+            parameters=parameters,
+            first_moment=jnp.zeros_like(parameters),
+            second_moment=jnp.zeros_like(parameters),
+            best_parameters=parameters,
+            step=0,
+            best_loss=float(initial_loss),
+            best_iteration=0,
+            patience_loss=float(initial_loss),
+            stall_count=0,
+            history=[initial_record],
+        )
+        _save_best_design(out_dir, state, compiled_fields)
+    else:
+        state = _load_checkpoint(Path(resume), fingerprint)
+
+    target_step = config.optimizer.iterations
+    if max_steps is not None:
+        if max_steps < 0:
+            raise ValueError("max_steps must be nonnegative")
+        target_step = min(target_step, state.step + max_steps)
+
+    early_stopped = False
+    while state.step < target_step:
+        iteration = state.step + 1
+        (
+            state.parameters,
+            state.first_moment,
+            state.second_moment,
+            training_loss,
+            gradient_norm,
+        ) = adam_step(
+            state.parameters,
+            state.first_moment,
+            state.second_moment,
+            jnp.asarray(iteration, dtype=jnp.float64),
+        )
+        hard_loss, hard_aux = hard_evaluate(state.parameters)
+        loss_value = float(hard_loss)
+        state.step = iteration
+        state.history.append(
+            _history_record(
+                iteration,
+                loss_value,
+                hard_aux,
+                float(training_loss),
+                float(gradient_norm),
+            )
+        )
+        if loss_value < state.best_loss:
+            state.best_loss = loss_value
+            state.best_iteration = iteration
+            state.best_parameters = state.parameters
+            _save_best_design(out_dir, state, compiled_fields)
+        if loss_value < state.patience_loss - config.optimizer.min_delta:
+            state.patience_loss = loss_value
+            state.stall_count = 0
+        else:
+            state.stall_count += 1
+        if iteration % config.optimizer.checkpoint_interval == 0:
+            _save_checkpoint(out_dir / "checkpoint.npz", state, fingerprint)
+        if (
+            config.optimizer.early_stopping_patience > 0
+            and state.stall_count >= config.optimizer.early_stopping_patience
+        ):
+            early_stopped = True
+            break
+
+    _save_checkpoint(out_dir / "checkpoint.npz", state, fingerprint)
+    if early_stopped:
+        status = "early_stopped"
+    elif state.step >= config.optimizer.iterations:
+        status = "complete"
+    else:
+        status = "incomplete"
+    metrics = _write_artifacts(
+        config,
+        out_dir,
+        status,
+        state,
+        source,
+        target,
+        grid,
+        compiled_fields,
+        hard_evaluate,
+        fingerprint,
+    )
+    return OptimizationResult(out_dir=out_dir, status=status, metrics=metrics)
+
+
+def _history_record(
+    iteration: int,
+    loss: float,
+    auxiliary: Any,
+    training_loss: float,
+    gradient_norm: float,
+) -> dict[str, Any]:
+    overlap, intensity, efficiency, total_variation = np.asarray(auxiliary)
+    return {
+        "iteration": iteration,
+        "loss": loss,
+        "training_loss": training_loss,
+        "mode_overlap": float(overlap),
+        "intensity_similarity": float(intensity),
+        "mode_power_efficiency": float(efficiency),
+        "total_variation": float(total_variation),
+        "gradient_norm": gradient_norm,
+    }
+
+
+def _make_mode(mode: DesignModeConfig, grid) -> np.ndarray:
+    kind = mode.kind.lower()
+    if kind == "gaussian":
+        return gaussian_mode(grid, mode.waist_m, center=mode.center_m)
+    if kind in {"hermite_gaussian", "hg"}:
+        return hermite_gaussian_mode(
+            grid,
+            mode.order,
+            mode.waist_m,
+            center=mode.center_m,
+        )
+    raise ValueError(f"unsupported design mode kind: {mode.kind}")
+
+
+def _save_checkpoint(
+    path: Path,
+    state: _OptimizationState,
+    fingerprint: str,
+) -> None:
+    np.savez_compressed(
+        path,
+        config_fingerprint=fingerprint,
+        parameters=np.asarray(state.parameters),
+        first_moment=np.asarray(state.first_moment),
+        second_moment=np.asarray(state.second_moment),
+        best_parameters=np.asarray(state.best_parameters),
+        step=state.step,
+        best_loss=state.best_loss,
+        best_iteration=state.best_iteration,
+        patience_loss=state.patience_loss,
+        stall_count=state.stall_count,
+        history=json.dumps(state.history, sort_keys=True),
+    )
+
+
+def _load_checkpoint(path: Path, fingerprint: str) -> _OptimizationState:
+    with np.load(path) as data:
+        saved_fingerprint = str(data["config_fingerprint"])
+        if saved_fingerprint != fingerprint:
+            raise ValueError("checkpoint config fingerprint does not match config")
+        return _OptimizationState(
+            parameters=jnp.asarray(data["parameters"]),
+            first_moment=jnp.asarray(data["first_moment"]),
+            second_moment=jnp.asarray(data["second_moment"]),
+            best_parameters=jnp.asarray(data["best_parameters"]),
+            step=int(data["step"]),
+            best_loss=float(data["best_loss"]),
+            best_iteration=int(data["best_iteration"]),
+            patience_loss=float(data["patience_loss"]),
+            stall_count=int(data["stall_count"]),
+            history=json.loads(str(data["history"])),
+        )
+
+
+def _save_best_design(out_dir: Path, state: _OptimizationState, compiled_fields) -> None:
+    phases, output, plane_fields = compiled_fields(state.best_parameters)
+    np.savez_compressed(
+        out_dir / "best_design.npz",
+        parameters=np.asarray(state.best_parameters),
+        phase_masks=np.asarray(phases),
+        output_field=np.asarray(output),
+        plane_fields=np.asarray(plane_fields),
+        iteration=state.best_iteration,
+        loss=state.best_loss,
+    )
+
+
+def _write_artifacts(
+    config: InverseDesignConfig,
+    out_dir: Path,
+    status: str,
+    state: _OptimizationState,
+    source: np.ndarray,
+    target: np.ndarray,
+    grid,
+    compiled_fields,
+    hard_evaluate,
+    fingerprint: str,
+) -> dict[str, Any]:
+    best_phases, best_output, best_plane_fields = compiled_fields(state.best_parameters)
+    final_phases, final_output, final_plane_fields = compiled_fields(state.parameters)
+    best_loss, best_aux = hard_evaluate(state.best_parameters)
+    best_record = _history_record(
+        state.best_iteration,
+        float(best_loss),
+        best_aux,
+        float(best_loss),
+        0.0,
+    )
+    initial = state.history[0]
+    gradient_evidence = _gradient_evidence()
+    metrics = {
+        "name": config.name,
+        "status": status,
+        "seed": config.seed,
+        "backend": "jax",
+        "device": jax.default_backend(),
+        "jax_x64": bool(jax.config.x64_enabled),
+        "config_fingerprint": fingerprint,
+        "iterations_completed": state.step,
+        "best_iteration": state.best_iteration,
+        "initial": initial,
+        "best": best_record,
+        "final": state.history[-1],
+        "mode_overlap_improvement": best_record["mode_overlap"]
+        - initial["mode_overlap"],
+        "loss_reduction": initial["loss"] - best_record["loss"],
+        "constraints": config.to_dict()["design"],
+        "objective": config.to_dict()["objective"],
+        "gradient_evidence": gradient_evidence,
+    }
+    environment = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "package_version": __version__,
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "jax_version": jax.__version__,
+        "dependencies": {
+            name: _package_version(name)
+            for name in ("jaxlib", "matplotlib", "numpy", "pytest", "scipy")
+        },
+        "device": str(jax.devices()[0]),
+        "git_commit": _git_value("rev-parse", "HEAD"),
+        "git_dirty": bool(_git_value("status", "--porcelain")),
+        "seed": config.seed,
+    }
+    (out_dir / "metrics.json").write_text(
+        json.dumps(metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "history.json").write_text(
+        json.dumps(state.history, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "resolved_config.json").write_text(
+        json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "environment.json").write_text(
+        json.dumps(environment, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    np.savez_compressed(
+        out_dir / "fields.npz",
+        x=grid.x,
+        y=grid.y,
+        input_field=source,
+        target_field=target,
+        best_output_field=np.asarray(best_output),
+        final_output_field=np.asarray(final_output),
+        best_phase_masks=np.asarray(best_phases),
+        final_phase_masks=np.asarray(final_phases),
+        best_plane_fields=np.asarray(best_plane_fields),
+        final_plane_fields=np.asarray(final_plane_fields),
+    )
+    (out_dir / "report.md").write_text(
+        _report_markdown(config, metrics, environment),
+        encoding="utf-8",
+    )
+    return metrics
+
+
+def _gradient_evidence() -> dict[str, Any]:
+    path = Path(__file__).resolve().parents[2] / "benchmarks" / "reference" / "jax_m2.json"
+    if not path.exists():
+        return {"path": str(path), "available": False}
+    evidence = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        "path": "benchmarks/reference/jax_m2.json",
+        "available": True,
+        "seed": evidence["seed"],
+        "declared_limits": evidence["declared_limits"],
+        "mode_relative_error": evidence["metrics"]["mode_gradient"][
+            "relative_error"
+        ],
+        "intensity_relative_error": evidence["metrics"]["intensity_gradient"][
+            "relative_error"
+        ],
+    }
+
+
+def _report_markdown(
+    config: InverseDesignConfig,
+    metrics: dict[str, Any],
+    environment: dict[str, Any],
+) -> str:
+    return f"""# {config.name} inverse-design report
+
+Status: **{metrics['status']}** after {metrics['iterations_completed']} updates.
+
+## Objective
+
+- Initial mode overlap: {metrics['initial']['mode_overlap']:.8f}
+- Best mode overlap: {metrics['best']['mode_overlap']:.8f}
+- Mode-overlap improvement: {metrics['mode_overlap_improvement']:.8f}
+- Best intensity similarity: {metrics['best']['intensity_similarity']:.8f}
+- Best input-referenced mode efficiency: {metrics['best']['mode_power_efficiency']:.8f}
+- Total loss reduction: {metrics['loss_reduction']:.8f}
+
+## Constraints and reproducibility
+
+- Seed: {config.seed}
+- Phase bounds: {config.design.phase_bounds_rad}
+- Smoothing passes: {config.design.smoothing_passes}
+- TV weight: {config.design.total_variation_weight}
+- Quantization levels: {config.design.quantization_levels}
+- Backend/device: JAX x64 / {metrics['device']}
+- Git commit: {environment['git_commit']} (dirty={environment['git_dirty']})
+- Config fingerprint: `{metrics['config_fingerprint']}`
+
+M2 centered directional gradient evidence is recorded in
+`benchmarks/reference/jax_m2.json`; the report metrics include its declared
+tolerances and measured mode/intensity relative errors.
+
+## Scientific scope
+
+This optimization uses a monochromatic coherent scalar Fresnel model. Objective
+improvement validates the deterministic discrete optimization workflow only. It
+does not establish robustness, band-limited angular-spectrum transfer, vector-
+Maxwell accuracy, or manufacturing readiness.
+"""
+
+
+def _config_fingerprint(config: InverseDesignConfig) -> str:
+    payload = json.dumps(config.to_dict(), sort_keys=True, separators=(",", ":"))
+    return sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _git_value(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip()
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _validate_config(config: InverseDesignConfig) -> None:
+    if not config.design.plane_distances_m or any(
+        distance <= 0.0 for distance in config.design.plane_distances_m
+    ):
+        raise ValueError("plane distances must be nonempty and positive")
+    if not np.isfinite(config.design.initial_scale) or config.design.initial_scale < 0.0:
+        raise ValueError("initial_scale must be finite and nonnegative")
+    lower, upper = config.design.phase_bounds_rad
+    if lower >= upper:
+        raise ValueError("phase bounds must be strictly increasing")
+    if config.design.smoothing_passes < 0:
+        raise ValueError("smoothing_passes must be nonnegative")
+    if config.design.total_variation_weight < 0.0:
+        raise ValueError("total_variation_weight must be nonnegative")
+    if (
+        config.design.quantization_levels is not None
+        and config.design.quantization_levels < 2
+    ):
+        raise ValueError("quantization_levels must be at least two")
+    if config.optimizer.iterations < 1:
+        raise ValueError("optimizer iterations must be positive")
+    if config.optimizer.learning_rate <= 0.0:
+        raise ValueError("learning rate must be positive")
+    if not 0.0 < config.optimizer.beta1 < 1.0:
+        raise ValueError("Adam beta1 must lie between zero and one")
+    if not 0.0 < config.optimizer.beta2 < 1.0:
+        raise ValueError("Adam beta2 must lie between zero and one")
+    if config.optimizer.epsilon <= 0.0:
+        raise ValueError("Adam epsilon must be positive")
+    if config.optimizer.checkpoint_interval < 1:
+        raise ValueError("checkpoint_interval must be positive")
+    if config.optimizer.early_stopping_patience < 0:
+        raise ValueError("early_stopping_patience must be nonnegative")
+    if config.optimizer.min_delta < 0.0:
+        raise ValueError("min_delta must be nonnegative")
+    if (
+        config.objective.mode_overlap_weight < 0.0
+        or config.objective.intensity_weight < 0.0
+    ):
+        raise ValueError("objective weights must be nonnegative")
+    if (
+        config.objective.mode_overlap_weight == 0.0
+        and config.objective.intensity_weight == 0.0
+        and config.design.total_variation_weight == 0.0
+    ):
+        raise ValueError("at least one objective or regularization weight must be positive")

--- a/src/quantum_dynamics_lab/wave_cli.py
+++ b/src/quantum_dynamics_lab/wave_cli.py
@@ -23,12 +23,32 @@ def main(argv: list[str] | None = None) -> int:
     propagate_parser.add_argument("config", type=Path)
     propagate_parser.add_argument("--out", type=Path, required=True)
 
+    optimize_parser = subparsers.add_parser(
+        "optimize",
+        help="Run constrained phase-mask inverse design",
+    )
+    optimize_parser.add_argument("config", type=Path)
+    optimize_parser.add_argument("--out", type=Path, required=True)
+    optimize_parser.add_argument("--resume", type=Path)
+
     args = parser.parse_args(argv)
     if args.command == "propagate":
         config = load_wave_config(args.config)
         run_path = save_wave_run(run_wave_propagation(config), args.out)
         print(run_path)
         return 0
+    if args.command == "optimize":
+        from .design_config import load_inverse_design_config
+        from .optimization import run_inverse_design
+
+        config = load_inverse_design_config(args.config)
+        result = run_inverse_design(
+            config,
+            args.out,
+            resume=args.resume,
+        )
+        print(result.out_dir)
+        return 0 if result.status in {"complete", "early_stopped"} else 1
     return 2
 
 

--- a/tests/test_optimization.py
+++ b/tests/test_optimization.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+from quantum_dynamics_lab.design_config import load_inverse_design_config
+from quantum_dynamics_lab.optimization import run_inverse_design
+from quantum_dynamics_lab.wave_cli import main as wave_main
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+SMOKE_CONFIG = REPOSITORY_ROOT / "examples" / "inverse_design_smoke.toml"
+
+
+def test_smoke_optimization_improves_and_writes_complete_artifacts(
+    tmp_path: Path,
+) -> None:
+    config = load_inverse_design_config(SMOKE_CONFIG)
+    result = run_inverse_design(config, tmp_path)
+
+    assert result.status in {"complete", "early_stopped"}
+    assert result.metrics["mode_overlap_improvement"] > 0.2
+    assert result.metrics["loss_reduction"] > 0.2
+    assert result.metrics["best"]["mode_overlap"] > result.metrics["initial"][
+        "mode_overlap"
+    ]
+    for name in (
+        "best_design.npz",
+        "checkpoint.npz",
+        "environment.json",
+        "fields.npz",
+        "history.json",
+        "metrics.json",
+        "report.md",
+        "resolved_config.json",
+    ):
+        assert (tmp_path / name).exists()
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "M2 centered directional gradient evidence" in report
+    assert "monochromatic coherent scalar Fresnel" in report
+    with np.load(tmp_path / "best_design.npz") as design:
+        assert design["phase_masks"].shape == (
+            len(config.design.plane_distances_m),
+            *config.grid.shape,
+        )
+
+
+def test_interrupted_resume_matches_uninterrupted_history(tmp_path: Path) -> None:
+    base = load_inverse_design_config(SMOKE_CONFIG)
+    config = replace(
+        base,
+        optimizer=replace(
+            base.optimizer,
+            iterations=8,
+            checkpoint_interval=4,
+            early_stopping_patience=0,
+        ),
+    )
+    full = run_inverse_design(config, tmp_path / "full")
+    partial = run_inverse_design(config, tmp_path / "resumed", max_steps=4)
+    assert partial.status == "incomplete"
+    resumed = run_inverse_design(
+        config,
+        tmp_path / "resumed",
+        resume=tmp_path / "resumed" / "checkpoint.npz",
+    )
+
+    assert full.status == resumed.status == "complete"
+    full_history = json.loads(
+        (tmp_path / "full" / "history.json").read_text(encoding="utf-8")
+    )
+    resumed_history = json.loads(
+        (tmp_path / "resumed" / "history.json").read_text(encoding="utf-8")
+    )
+    assert resumed_history == full_history
+    assert resumed.metrics["best"] == full.metrics["best"]
+    with np.load(tmp_path / "full" / "checkpoint.npz") as full_checkpoint:
+        with np.load(
+            tmp_path / "resumed" / "checkpoint.npz"
+        ) as resumed_checkpoint:
+            np.testing.assert_array_equal(
+                resumed_checkpoint["parameters"],
+                full_checkpoint["parameters"],
+            )
+
+
+def test_early_stopping_fingerprint_guard_and_cli(tmp_path: Path) -> None:
+    base = load_inverse_design_config(SMOKE_CONFIG)
+    early_config = replace(
+        base,
+        optimizer=replace(
+            base.optimizer,
+            iterations=20,
+            early_stopping_patience=2,
+            min_delta=10.0,
+            checkpoint_interval=1,
+        ),
+    )
+    early = run_inverse_design(early_config, tmp_path / "early")
+    assert early.status == "early_stopped"
+    assert early.metrics["iterations_completed"] == 2
+    changed = replace(early_config, seed=early_config.seed + 1)
+    with pytest.raises(ValueError, match="fingerprint"):
+        run_inverse_design(
+            changed,
+            tmp_path / "early",
+            resume=tmp_path / "early" / "checkpoint.npz",
+        )
+
+    cli_config = replace(
+        base,
+        optimizer=replace(
+            base.optimizer,
+            iterations=2,
+            early_stopping_patience=0,
+            checkpoint_interval=1,
+        ),
+    )
+    config_path = tmp_path / "cli.toml"
+    config_path.write_text(
+        SMOKE_CONFIG.read_text(encoding="utf-8")
+        .replace("iterations = 30", "iterations = 2")
+        .replace("early_stopping_patience = 15", "early_stopping_patience = 0")
+        .replace("checkpoint_interval = 5", "checkpoint_interval = 1"),
+        encoding="utf-8",
+    )
+    assert cli_config.optimizer.iterations == 2
+    assert wave_main(
+        ["optimize", str(config_path), "--out", str(tmp_path / "cli")]
+    ) == 0
+
+
+def test_saved_quantized_best_design_uses_hard_levels(tmp_path: Path) -> None:
+    base = load_inverse_design_config(SMOKE_CONFIG)
+    config = replace(
+        base,
+        design=replace(base.design, quantization_levels=4),
+        optimizer=replace(
+            base.optimizer,
+            iterations=2,
+            checkpoint_interval=1,
+            early_stopping_patience=0,
+        ),
+    )
+
+    result = run_inverse_design(config, tmp_path)
+
+    assert result.status == "complete"
+    with np.load(tmp_path / "best_design.npz") as design:
+        phase_masks = design["phase_masks"]
+    expected = -np.pi + np.arange(4) * (2.0 * np.pi / 4)
+    distances = np.min(
+        np.abs(np.unique(phase_masks)[:, None] - expected[None, :]),
+        axis=1,
+    )
+    np.testing.assert_allclose(distances, 0.0, atol=1e-15)


### PR DESCRIPTION
Closes #44

## Change

Adds typed inverse-design configs, deterministic JAX x64 Adam, constrained multi-plane Fresnel optimization, early stopping, interval checkpoints, config-fingerprint restart protection, hard-evaluated best-design snapshots, and a lazy `wave-lab optimize` command that leaves forward/legacy imports JAX-optional.

Every run writes the required history, resolved config, environment/dependency provenance, fields, metrics, best design, full optimizer checkpoint, and Markdown report. The report exposes objective/constraint semantics and links the committed M2 gradient evidence.

## Validation and evidence

- Focused optimization suite — 4 passed.
- `JAX_ENABLE_X64=1 uv run --extra jax --extra ui pytest` — 79 passed.
- Committed smoke initial/best mode overlap: `0.00271376` / `0.86730206`.
- Mode-overlap improvement: `0.86458831`.
- Total loss reduction: `0.88598917`.
- Deterministic best iteration: 30 of 30.
- Interrupted at checkpoint 4 then resumed to 8 produces history exactly equal to uninterrupted execution and identical parameter arrays.
- Early stopping triggers deterministically at iteration 2 in the guard test.
- Changed config/seed is rejected by SHA-256 fingerprint.
- Saved quantized designs contain only the declared hard phase levels.
- Environment records package/dependency versions, git commit/dirty state, backend/device, x64 status, and seed.

## Milestone status

All M3 exit gates now pass: reproducible committed inputs, visible objective/constraint/gradient evidence, deterministic improvement, complete artifacts, and restart equivalence. `ROADMAP.md` marks M3 complete and `AGENTS.md` advances priority to M4.

## Interpretation and compatibility

The smoke result validates the discrete optimization workflow only; it makes no robustness or model-transfer claim. All M2/M1/quantum/CLI/dashboard regressions remain green and generated run directories remain ignored.

This is a stacked draft PR targeting the #42 branch.