### PR TITLE
Build robust Gaussian-to-HG10 flagship comparison

### DIFF
--- a/benchmarks/reference/README.md
+++ b/benchmarks/reference/README.md
@@ -62,3 +62,20 @@ JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_jax_
 
 The gradient tolerances validate the implemented discrete Fresnel computation,
 not the scalar physical model or an optimization result.
+
+## Robust flagship M4
+
+`flagship_m4.json` records the deterministic four-baseline Gaussian-to-HG10
+comparison, including nominal, held-out mean, and held-out worst metrics. Its
+robustness and held-out scenario signatures are disjoint and both cover
+wavelength, alignment, phase-depth, and plane-spacing perturbations.
+
+Regenerate the reference with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_flagship_m4
+```
+
+This reference establishes the Fresnel-model comparison only. The v1.0 model-
+transfer conclusion additionally requires the committed BLAS and convergence
+evidence.

--- a/benchmarks/reference/flagship_m4.json
+++ b/benchmarks/reference/flagship_m4.json
@@ -1,0 +1,100 @@
+{
+  "schema_version": 1,
+  "name": "robust_gaussian_to_hg10",
+  "seed": 20260714,
+  "required_baselines": [
+    "no_masks",
+    "one_optimized_mask",
+    "three_nominal_masks",
+    "three_robust_masks"
+  ],
+  "common_physics": {
+    "shape": [32, 32],
+    "extent_m": [0.004, 0.004],
+    "wavelength_m": 1.064e-06,
+    "waist_m": 0.00055,
+    "plane_distances_m": [0.04, 0.05, 0.03],
+    "total_length_m": 0.12,
+    "aperture_radius_m": 0.0015,
+    "source": "Gaussian",
+    "target": "HG10"
+  },
+  "scenario_sets_disjoint": true,
+  "baselines": {
+    "no_masks": {
+      "nominal": {
+        "mode_overlap": 3.995286361569004e-22,
+        "intensity_similarity": 0.5824911604649308,
+        "mode_power_efficiency": 3.9952812274742094e-22
+      },
+      "held_out_mean": {
+        "mode_overlap": 3.999439465775733e-22,
+        "intensity_similarity": 0.5824920299084323,
+        "mode_power_efficiency": 3.999434323657159e-22
+      },
+      "held_out_worst": {
+        "mode_overlap": 3.6424621427368936e-22,
+        "intensity_similarity": 0.5822405823904026,
+        "mode_power_efficiency": 3.64245755767084e-22
+      }
+    },
+    "one_optimized_mask": {
+      "nominal": {
+        "mode_overlap": 0.6082995320173632,
+        "intensity_similarity": 0.716561031490579,
+        "mode_power_efficiency": 0.6082268602293688
+      },
+      "held_out_mean": {
+        "mode_overlap": 0.5838580344793051,
+        "intensity_similarity": 0.6924200477068398,
+        "mode_power_efficiency": 0.58378877514778
+      },
+      "held_out_worst": {
+        "mode_overlap": 0.45692422359988244,
+        "intensity_similarity": 0.5973979134518795,
+        "mode_power_efficiency": 0.45687109003986054
+      }
+    },
+    "three_nominal_masks": {
+      "nominal": {
+        "mode_overlap": 0.9365109601779865,
+        "intensity_similarity": 0.9626200495410477,
+        "mode_power_efficiency": 0.9364570321086794
+      },
+      "held_out_mean": {
+        "mode_overlap": 0.8994835337345692,
+        "intensity_similarity": 0.9313873282315075,
+        "mode_power_efficiency": 0.8994300347156678
+      },
+      "held_out_worst": {
+        "mode_overlap": 0.7621715111711788,
+        "intensity_similarity": 0.8031989896441659,
+        "mode_power_efficiency": 0.7621284055260628
+      }
+    },
+    "three_robust_masks": {
+      "nominal": {
+        "mode_overlap": 0.924105464735772,
+        "intensity_similarity": 0.9605608589753052,
+        "mode_power_efficiency": 0.9240607706865561
+      },
+      "held_out_mean": {
+        "mode_overlap": 0.8878058662475234,
+        "intensity_similarity": 0.9298407084404011,
+        "mode_power_efficiency": 0.887760871726099
+      },
+      "held_out_worst": {
+        "mode_overlap": 0.7813492347219079,
+        "intensity_similarity": 0.8273429494502405,
+        "mode_power_efficiency": 0.7813151931036638
+      }
+    }
+  },
+  "robust_worst_case_overlap_advantage": 0.01917772355072911,
+  "robustness_claim_passed": true,
+  "declared_limits": {
+    "minimum_robust_worst_case_advantage": 0.01,
+    "reproduction_absolute_tolerance": 2e-10,
+    "reproduction_relative_tolerance": 2e-10
+  }
+}

--- a/benchmarks/reference/generate_flagship_m4.py
+++ b/benchmarks/reference/generate_flagship_m4.py
@@ -1,0 +1,30 @@
+"""Regenerate the small robust-flagship M4 comparison reference."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quantum_dynamics_lab.flagship import run_flagship
+from quantum_dynamics_lab.flagship_config import load_flagship_config
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPOSITORY_ROOT / "examples" / "robust_flagship.toml"
+REFERENCE_PATH = Path(__file__).with_name("flagship_m4.json")
+
+
+def generate_metrics() -> dict:
+    return run_flagship(load_flagship_config(CONFIG_PATH)).metrics
+
+
+def main() -> None:
+    REFERENCE_PATH.write_text(
+        json.dumps(generate_metrics(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(REFERENCE_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/flagship-experiment.md
+++ b/docs/flagship-experiment.md
@@ -1,0 +1,32 @@
+# Robust Gaussian-to-HG10 Flagship
+
+The committed `examples/robust_flagship.toml` asks whether a low-cost
+differentiable scalar propagator can design a phase-only Gaussian-to-HG10 mode
+converter that remains useful under held-out wavelength, alignment, phase-depth,
+and plane-spacing perturbations.
+
+The required comparison uses common source, target, aperture, total length,
+sampling, constraints, metrics, and seed:
+
+1. no phase masks;
+2. one optimized phase mask;
+3. three phase masks optimized nominally;
+4. three phase masks optimized over the declared robustness ensemble.
+
+The optimization ensemble includes nominal conditions plus distinct variations
+of all four perturbation classes. The held-out set uses different values and, for
+alignment, diagonal directions not used during optimization. Scenario signatures
+are asserted disjoint in tests and recorded with every generated report.
+
+Run the comparison with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax wave-lab flagship \
+  examples/robust_flagship.toml --out runs/robust-flagship
+```
+
+The initial report contains nominal, held-out mean, and held-out worst overlap,
+intensity similarity, and input-referenced mode efficiency for all four
+baselines. It is still a Fresnel-only result. The M4 conclusion is not complete
+until independent BLAS model transfer and grid, padding, aperture, and
+propagation-step convergence are recorded.

--- a/examples/robust_flagship.toml
+++ b/examples/robust_flagship.toml
@@ -1,0 +1,51 @@
+name = "robust_gaussian_to_hg10"
+seed = 20260714
+
+[grid]
+shape = 32
+extent_m = 0.004
+wavelength_m = 1.064e-6
+
+[system]
+waist_m = 0.00055
+plane_distances_m = [0.04, 0.05, 0.03]
+aperture_radius_m = 0.0015
+
+[constraints]
+phase_bounds_rad = [-3.141592653589793, 3.141592653589793]
+smoothing_passes = 1
+total_variation_weight = 0.0001
+
+[objective]
+intensity_weight = 0.05
+worst_case_weight = 1.0
+
+[optimizer]
+iterations = 60
+learning_rate = 0.08
+initial_scale = 0.2
+
+[robustness]
+optimization_scenarios = [
+  { name = "opt_nominal", kind = "nominal" },
+  { name = "opt_wavelength_low", kind = "wavelength", wavelength_scale = 0.98 },
+  { name = "opt_wavelength_high", kind = "wavelength", wavelength_scale = 1.02 },
+  { name = "opt_align_x_low", kind = "alignment", alignment_pixels = [0, -1] },
+  { name = "opt_align_x_high", kind = "alignment", alignment_pixels = [0, 1] },
+  { name = "opt_align_y_low", kind = "alignment", alignment_pixels = [-1, 0] },
+  { name = "opt_align_y_high", kind = "alignment", alignment_pixels = [1, 0] },
+  { name = "opt_phase_low", kind = "phase_depth", phase_depth_scale = 0.9 },
+  { name = "opt_phase_high", kind = "phase_depth", phase_depth_scale = 1.1 },
+  { name = "opt_spacing_low", kind = "plane_spacing", spacing_scale = 0.95 },
+  { name = "opt_spacing_high", kind = "plane_spacing", spacing_scale = 1.05 },
+]
+held_out_scenarios = [
+  { name = "held_wavelength_low", kind = "wavelength", wavelength_scale = 0.99 },
+  { name = "held_wavelength_high", kind = "wavelength", wavelength_scale = 1.01 },
+  { name = "held_align_diag_low", kind = "alignment", alignment_pixels = [-1, -1] },
+  { name = "held_align_diag_high", kind = "alignment", alignment_pixels = [1, 1] },
+  { name = "held_phase_low", kind = "phase_depth", phase_depth_scale = 0.95 },
+  { name = "held_phase_high", kind = "phase_depth", phase_depth_scale = 1.05 },
+  { name = "held_spacing_low", kind = "plane_spacing", spacing_scale = 0.975 },
+  { name = "held_spacing_high", kind = "plane_spacing", spacing_scale = 1.025 },
+]

--- a/src/quantum_dynamics_lab/flagship.py
+++ b/src/quantum_dynamics_lab/flagship.py
@@ -1,0 +1,549 @@
+"""Robust multi-plane Gaussian-to-HG10 flagship comparison."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+from typing import Any
+import json
+import platform
+import subprocess
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .constraints import phase_total_variation
+from .flagship_config import FlagshipConfig, PerturbationScenario
+from .jax_constraints import parameterize_phase_jax, phase_total_variation_jax
+from .jax_objectives import (
+    intensity_similarity_jax,
+    mode_overlap_jax,
+    mode_power_efficiency_jax,
+)
+from .jax_propagation import fresnel_transfer_jax, propagate_fresnel_jax
+from .optics import circular_aperture, gaussian_mode, hermite_gaussian_mode, make_optical_grid
+
+
+BASELINE_NAMES = (
+    "no_masks",
+    "one_optimized_mask",
+    "three_nominal_masks",
+    "three_robust_masks",
+)
+
+
+@dataclass(frozen=True)
+class FlagshipResult:
+    metrics: dict[str, Any]
+    designs: dict[str, np.ndarray]
+    histories: dict[str, list[dict[str, float]]]
+
+
+def run_flagship(config: FlagshipConfig, out_dir: str | Path | None = None) -> FlagshipResult:
+    """Optimize the required baseline ladder and evaluate held-out scenarios."""
+
+    jax.config.update("jax_enable_x64", True)
+    _validate_config(config)
+    grid = make_optical_grid(
+        config.grid.shape,
+        config.grid.extent_m,
+        config.grid.wavelength_m,
+    )
+    source = gaussian_mode(grid, config.system.waist_m)
+    target = hermite_gaussian_mode(grid, (1, 0), config.system.waist_m)
+    aperture = circular_aperture(grid, config.system.aperture_radius_m)
+    nominal = PerturbationScenario(name="nominal", kind="nominal")
+
+    one_phase, one_history = _optimize_design(
+        config,
+        grid,
+        source,
+        target,
+        aperture,
+        mask_count=1,
+        scenarios=(nominal,),
+        seed=config.seed,
+    )
+    nominal_phase, nominal_history = _optimize_design(
+        config,
+        grid,
+        source,
+        target,
+        aperture,
+        mask_count=3,
+        scenarios=(nominal,),
+        seed=config.seed,
+    )
+    robust_phase, robust_history = _optimize_design(
+        config,
+        grid,
+        source,
+        target,
+        aperture,
+        mask_count=3,
+        scenarios=config.optimization_scenarios,
+        seed=config.seed,
+    )
+    zero_phase = np.zeros((3, *grid.shape), dtype=np.float64)
+    one_expanded = np.concatenate(
+        [one_phase, np.zeros((2, *grid.shape), dtype=np.float64)],
+        axis=0,
+    )
+    designs = {
+        "no_masks": zero_phase,
+        "one_optimized_mask": one_expanded,
+        "three_nominal_masks": nominal_phase,
+        "three_robust_masks": robust_phase,
+    }
+    baselines = {
+        name: _evaluate_design(
+            phase_masks,
+            config,
+            grid,
+            source,
+            target,
+            aperture,
+            nominal,
+            config.held_out_scenarios,
+        )
+        for name, phase_masks in designs.items()
+    }
+    robust_advantage = (
+        baselines["three_robust_masks"]["held_out_worst"]["mode_overlap"]
+        - baselines["three_nominal_masks"]["held_out_worst"]["mode_overlap"]
+    )
+    metrics = {
+        "schema_version": 1,
+        "name": config.name,
+        "seed": config.seed,
+        "scope": "monochromatic coherent scalar free-space Fresnel flagship",
+        "required_baselines": list(BASELINE_NAMES),
+        "common_physics": {
+            "shape": list(grid.shape),
+            "extent_m": list(grid.extent),
+            "wavelength_m": grid.wavelength,
+            "waist_m": config.system.waist_m,
+            "plane_distances_m": list(config.system.plane_distances_m),
+            "total_length_m": sum(config.system.plane_distances_m),
+            "aperture_radius_m": config.system.aperture_radius_m,
+            "source": "Gaussian",
+            "target": "HG10",
+        },
+        "optimization_scenarios": [
+            _scenario_dict(scenario) for scenario in config.optimization_scenarios
+        ],
+        "held_out_scenarios": [
+            _scenario_dict(scenario) for scenario in config.held_out_scenarios
+        ],
+        "scenario_sets_disjoint": _scenario_sets_disjoint(config),
+        "baselines": baselines,
+        "robust_worst_case_overlap_advantage": robust_advantage,
+        "robustness_claim_passed": robust_advantage > 0.0,
+        "declared_limits": {
+            "minimum_robust_worst_case_advantage": 0.01,
+            "reproduction_absolute_tolerance": 2.0e-10,
+            "reproduction_relative_tolerance": 2.0e-10,
+        },
+    }
+    histories = {
+        "one_optimized_mask": one_history,
+        "three_nominal_masks": nominal_history,
+        "three_robust_masks": robust_history,
+    }
+    result = FlagshipResult(metrics=metrics, designs=designs, histories=histories)
+    if out_dir is not None:
+        _write_flagship_artifacts(config, Path(out_dir), result)
+    return result
+
+
+def _optimize_design(
+    config: FlagshipConfig,
+    grid,
+    source: np.ndarray,
+    target: np.ndarray,
+    aperture: np.ndarray,
+    *,
+    mask_count: int,
+    scenarios: tuple[PerturbationScenario, ...],
+    seed: int,
+) -> tuple[np.ndarray, list[dict[str, float]]]:
+    source_jax = jnp.asarray(source)
+    target_jax = jnp.asarray(target)
+    aperture_jax = jnp.asarray(aperture)
+    runtime = [
+        (
+            scenario,
+            jnp.stack(
+                [
+                    fresnel_transfer_jax(
+                        jnp.asarray(grid.FX),
+                        jnp.asarray(grid.FY),
+                        grid.wavelength * scenario.wavelength_scale,
+                        distance * scenario.spacing_scale,
+                    )
+                    for distance in config.system.plane_distances_m
+                ]
+            ),
+        )
+        for scenario in scenarios
+    ]
+
+    def constrained(parameters):
+        phases = parameterize_phase_jax(
+            parameters,
+            bounds=config.constraints.phase_bounds_rad,
+            smoothing_passes=config.constraints.smoothing_passes,
+        )
+        if mask_count == 1:
+            phases = jnp.concatenate(
+                [phases, jnp.zeros((2, *grid.shape), dtype=phases.dtype)],
+                axis=0,
+            )
+        return phases
+
+    def scenario_metrics(phases, scenario, transfers):
+        shifted = jnp.roll(
+            phases,
+            shift=scenario.alignment_pixels,
+            axis=(-2, -1),
+        )
+        scaled = shifted * scenario.phase_depth_scale
+        field = source_jax
+        for plane in range(3):
+            field = field * aperture_jax * jnp.exp(1j * scaled[plane])
+            field = propagate_fresnel_jax(field, transfers[plane])
+        return jnp.asarray(
+            [
+                mode_overlap_jax(field, target_jax, grid.sample_area),
+                intensity_similarity_jax(field, target_jax, grid.sample_area),
+                mode_power_efficiency_jax(field, target_jax, 1.0, grid.sample_area),
+            ]
+        )
+
+    def objective(parameters):
+        phases = constrained(parameters)
+        all_metrics = jnp.stack(
+            [
+                scenario_metrics(phases, scenario, transfers)
+                for scenario, transfers in runtime
+            ]
+        )
+        scenario_losses = (1.0 - all_metrics[:, 0]) + config.objective.intensity_weight * (
+            1.0 - all_metrics[:, 1]
+        )
+        aggregate = jnp.mean(scenario_losses)
+        if len(runtime) > 1:
+            aggregate = aggregate + config.objective.worst_case_weight * jnp.max(
+                scenario_losses
+            )
+        active_phases = phases[:mask_count]
+        tv = jnp.mean(jax.vmap(phase_total_variation_jax)(active_phases))
+        loss = aggregate + config.constraints.total_variation_weight * tv
+        auxiliary = jnp.asarray(
+            [
+                jnp.mean(all_metrics[:, 0]),
+                jnp.min(all_metrics[:, 0]),
+                jnp.mean(all_metrics[:, 2]),
+                jnp.min(all_metrics[:, 2]),
+                tv,
+            ]
+        )
+        return loss, auxiliary
+
+    @jax.jit
+    def step(parameters, first_moment, second_moment, iteration):
+        (_, _), gradient = jax.value_and_grad(objective, has_aux=True)(parameters)
+        first_moment = (
+            config.optimizer.beta1 * first_moment
+            + (1.0 - config.optimizer.beta1) * gradient
+        )
+        second_moment = (
+            config.optimizer.beta2 * second_moment
+            + (1.0 - config.optimizer.beta2) * gradient**2
+        )
+        first_unbiased = first_moment / (1.0 - config.optimizer.beta1**iteration)
+        second_unbiased = second_moment / (1.0 - config.optimizer.beta2**iteration)
+        parameters = parameters - config.optimizer.learning_rate * first_unbiased / (
+            jnp.sqrt(second_unbiased) + config.optimizer.epsilon
+        )
+        loss, auxiliary = objective(parameters)
+        return parameters, first_moment, second_moment, loss, auxiliary
+
+    rng = np.random.default_rng(seed)
+    parameters = jnp.asarray(
+        config.optimizer.initial_scale
+        * rng.standard_normal((mask_count, *grid.shape)),
+        dtype=jnp.float64,
+    )
+    first_moment = jnp.zeros_like(parameters)
+    second_moment = jnp.zeros_like(parameters)
+    initial_loss, initial_auxiliary = jax.jit(objective)(parameters)
+    history = [_flagship_history(0, initial_loss, initial_auxiliary)]
+    best_loss = float(initial_loss)
+    best_parameters = parameters
+    for iteration in range(1, config.optimizer.iterations + 1):
+        parameters, first_moment, second_moment, loss, auxiliary = step(
+            parameters,
+            first_moment,
+            second_moment,
+            jnp.asarray(iteration, dtype=jnp.float64),
+        )
+        history.append(_flagship_history(iteration, loss, auxiliary))
+        if float(loss) < best_loss:
+            best_loss = float(loss)
+            best_parameters = parameters
+    best_phase = np.asarray(constrained(best_parameters))[:mask_count]
+    return best_phase, history
+
+
+def _flagship_history(iteration: int, loss: Any, auxiliary: Any) -> dict[str, float]:
+    mean_overlap, worst_overlap, mean_efficiency, worst_efficiency, tv = np.asarray(
+        auxiliary
+    )
+    return {
+        "iteration": float(iteration),
+        "loss": float(loss),
+        "mean_overlap": float(mean_overlap),
+        "worst_overlap": float(worst_overlap),
+        "mean_efficiency": float(mean_efficiency),
+        "worst_efficiency": float(worst_efficiency),
+        "total_variation": float(tv),
+    }
+
+
+def _evaluate_design(
+    phase_masks: np.ndarray,
+    config: FlagshipConfig,
+    grid,
+    source: np.ndarray,
+    target: np.ndarray,
+    aperture: np.ndarray,
+    nominal: PerturbationScenario,
+    held_out: tuple[PerturbationScenario, ...],
+) -> dict[str, Any]:
+    scenarios = (nominal, *held_out)
+    evaluated = [
+        _evaluate_scenario(
+            phase_masks,
+            config,
+            grid,
+            source,
+            target,
+            aperture,
+            scenario,
+        )
+        for scenario in scenarios
+    ]
+    held = evaluated[1:]
+    return {
+        "nominal": evaluated[0],
+        "held_out": held,
+        "held_out_mean": {
+            key: float(np.mean([item[key] for item in held]))
+            for key in ("mode_overlap", "intensity_similarity", "mode_power_efficiency")
+        },
+        "held_out_worst": {
+            key: float(np.min([item[key] for item in held]))
+            for key in ("mode_overlap", "intensity_similarity", "mode_power_efficiency")
+        },
+        "phase_total_variation": float(
+            np.mean([phase_total_variation(phase) for phase in phase_masks])
+        ),
+    }
+
+
+def _evaluate_scenario(
+    phase_masks: np.ndarray,
+    config: FlagshipConfig,
+    grid,
+    source: np.ndarray,
+    target: np.ndarray,
+    aperture: np.ndarray,
+    scenario: PerturbationScenario,
+) -> dict[str, Any]:
+    from .objectives import intensity_similarity, mode_overlap, mode_power_efficiency
+    from .optics_propagation import propagate_fresnel
+
+    phases = np.roll(
+        phase_masks,
+        shift=scenario.alignment_pixels,
+        axis=(-2, -1),
+    ) * scenario.phase_depth_scale
+    scenario_grid = make_optical_grid(
+        grid.shape,
+        grid.extent,
+        grid.wavelength * scenario.wavelength_scale,
+    )
+    field = source.copy()
+    for phase, distance in zip(
+        phases,
+        config.system.plane_distances_m,
+        strict=True,
+    ):
+        field = field * aperture * np.exp(1j * phase)
+        field = propagate_fresnel(
+            field,
+            scenario_grid,
+            distance * scenario.spacing_scale,
+        )
+    return {
+        "name": scenario.name,
+        "kind": scenario.kind,
+        "mode_overlap": mode_overlap(field, target, grid.sample_area),
+        "intensity_similarity": intensity_similarity(field, target, grid.sample_area),
+        "mode_power_efficiency": mode_power_efficiency(
+            field,
+            target,
+            1.0,
+            grid.sample_area,
+        ),
+    }
+
+
+def _scenario_dict(scenario: PerturbationScenario) -> dict[str, Any]:
+    return {
+        "name": scenario.name,
+        "kind": scenario.kind,
+        "wavelength_scale": scenario.wavelength_scale,
+        "alignment_pixels": list(scenario.alignment_pixels),
+        "phase_depth_scale": scenario.phase_depth_scale,
+        "spacing_scale": scenario.spacing_scale,
+    }
+
+
+def _scenario_sets_disjoint(config: FlagshipConfig) -> bool:
+    optimization = {scenario.signature for scenario in config.optimization_scenarios}
+    held_out = {scenario.signature for scenario in config.held_out_scenarios}
+    return optimization.isdisjoint(held_out)
+
+
+def _validate_config(config: FlagshipConfig) -> None:
+    if tuple(sorted(set(BASELINE_NAMES))) != tuple(sorted(BASELINE_NAMES)):
+        raise AssertionError("baseline names must be unique")
+    if not config.optimization_scenarios or not config.held_out_scenarios:
+        raise ValueError("optimization and held-out scenario sets must be nonempty")
+    if not _scenario_sets_disjoint(config):
+        raise ValueError("optimization and held-out scenarios must be disjoint")
+    required_kinds = {"wavelength", "alignment", "phase_depth", "plane_spacing"}
+    for label, scenarios in (
+        ("optimization", config.optimization_scenarios),
+        ("held-out", config.held_out_scenarios),
+    ):
+        kinds = {scenario.kind for scenario in scenarios}
+        missing = required_kinds - kinds
+        if missing:
+            raise ValueError(f"{label} scenarios missing perturbation kinds: {missing}")
+    names = [
+        scenario.name
+        for scenario in (*config.optimization_scenarios, *config.held_out_scenarios)
+    ]
+    if len(names) != len(set(names)):
+        raise ValueError("scenario names must be unique")
+    if config.optimizer.iterations < 1 or config.optimizer.learning_rate <= 0.0:
+        raise ValueError("flagship optimizer settings must be positive")
+
+
+def _write_flagship_artifacts(
+    config: FlagshipConfig,
+    out_dir: Path,
+    result: FlagshipResult,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(out_dir / "designs.npz", **result.designs)
+    for name, phase_masks in result.designs.items():
+        np.savez_compressed(out_dir / f"{name}.npz", phase_masks=phase_masks)
+    (out_dir / "metrics.json").write_text(
+        json.dumps(result.metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "histories.json").write_text(
+        json.dumps(result.histories, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "resolved_config.json").write_text(
+        json.dumps(config.to_dict(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    scenarios = {
+        "optimization": result.metrics["optimization_scenarios"],
+        "held_out": result.metrics["held_out_scenarios"],
+    }
+    (out_dir / "scenarios.json").write_text(
+        json.dumps(scenarios, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    environment = {
+        "created_at": datetime.now(UTC).isoformat(),
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "jax_version": jax.__version__,
+        "dependencies": {
+            name: _package_version(name)
+            for name in ("jaxlib", "matplotlib", "numpy", "pytest", "scipy")
+        },
+        "jax_x64": bool(jax.config.x64_enabled),
+        "device": str(jax.devices()[0]),
+        "git_commit": _git_value("rev-parse", "HEAD"),
+        "git_dirty": bool(_git_value("status", "--porcelain")),
+        "seed": config.seed,
+    }
+    (out_dir / "environment.json").write_text(
+        json.dumps(environment, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "report.md").write_text(
+        _flagship_report(result.metrics),
+        encoding="utf-8",
+    )
+
+
+def _flagship_report(metrics: dict[str, Any]) -> str:
+    rows = []
+    for name in BASELINE_NAMES:
+        baseline = metrics["baselines"][name]
+        rows.append(
+            f"| {name} | {baseline['nominal']['mode_overlap']:.6f} | "
+            f"{baseline['held_out_mean']['mode_overlap']:.6f} | "
+            f"{baseline['held_out_worst']['mode_overlap']:.6f} | "
+            f"{baseline['held_out_worst']['mode_power_efficiency']:.6f} |"
+        )
+    claim = "passed" if metrics["robustness_claim_passed"] else "did not pass"
+    return f"""# Robust Gaussian-to-HG10 flagship
+
+| Baseline | Nominal overlap | Held-out mean overlap | Held-out worst overlap | Held-out worst efficiency |
+| --- | ---: | ---: | ---: | ---: |
+{chr(10).join(rows)}
+
+Optimization and held-out scenarios are explicitly disjoint and both cover
+wavelength, alignment, phase-depth, and plane-spacing perturbations. The robust
+worst-case advantage over the nominal three-mask design is
+`{metrics['robust_worst_case_overlap_advantage']:.6f}`; the declared robustness
+comparison **{claim}** under the Fresnel model.
+
+This is an initial scalar-Fresnel comparison. Independent BLAS transfer and
+grid/padding/aperture/step convergence are separate M4 gates and must pass before
+this result is presented as the v1.0 flagship conclusion.
+"""
+
+
+def _package_version(name: str) -> str | None:
+    try:
+        return version(name)
+    except PackageNotFoundError:
+        return None
+
+
+def _git_value(*args: str) -> str | None:
+    try:
+        completed = subprocess.run(
+            ["git", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return completed.stdout.strip()

--- a/src/quantum_dynamics_lab/flagship_config.py
+++ b/src/quantum_dynamics_lab/flagship_config.py
@@ -1,0 +1,184 @@
+"""Configuration for the robust Gaussian-to-HG10 flagship experiment."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+import math
+import tomllib
+
+from .wave_config import OpticalGridConfig
+
+
+@dataclass(frozen=True)
+class PerturbationScenario:
+    name: str
+    kind: str
+    wavelength_scale: float = 1.0
+    alignment_pixels: tuple[int, int] = (0, 0)
+    phase_depth_scale: float = 1.0
+    spacing_scale: float = 1.0
+
+    @property
+    def signature(self) -> tuple[Any, ...]:
+        return (
+            self.kind,
+            self.wavelength_scale,
+            self.alignment_pixels,
+            self.phase_depth_scale,
+            self.spacing_scale,
+        )
+
+
+@dataclass(frozen=True)
+class FlagshipSystemConfig:
+    waist_m: float = 0.55e-3
+    plane_distances_m: tuple[float, float, float] = (0.04, 0.05, 0.03)
+    aperture_radius_m: float = 1.5e-3
+
+
+@dataclass(frozen=True)
+class FlagshipConstraintConfig:
+    phase_bounds_rad: tuple[float, float] = (-math.pi, math.pi)
+    smoothing_passes: int = 1
+    total_variation_weight: float = 1.0e-4
+
+
+@dataclass(frozen=True)
+class FlagshipObjectiveConfig:
+    intensity_weight: float = 0.05
+    worst_case_weight: float = 0.5
+
+
+@dataclass(frozen=True)
+class FlagshipOptimizerConfig:
+    iterations: int = 60
+    learning_rate: float = 0.08
+    beta1: float = 0.9
+    beta2: float = 0.999
+    epsilon: float = 1.0e-8
+    initial_scale: float = 0.2
+
+
+@dataclass(frozen=True)
+class FlagshipConfig:
+    name: str = "robust_gaussian_to_hg10"
+    seed: int = 20260714
+    grid: OpticalGridConfig = field(default_factory=OpticalGridConfig)
+    system: FlagshipSystemConfig = field(default_factory=FlagshipSystemConfig)
+    constraints: FlagshipConstraintConfig = field(
+        default_factory=FlagshipConstraintConfig
+    )
+    objective: FlagshipObjectiveConfig = field(default_factory=FlagshipObjectiveConfig)
+    optimizer: FlagshipOptimizerConfig = field(default_factory=FlagshipOptimizerConfig)
+    optimization_scenarios: tuple[PerturbationScenario, ...] = ()
+    held_out_scenarios: tuple[PerturbationScenario, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def load_flagship_config(path: str | Path) -> FlagshipConfig:
+    path = Path(path)
+    data = tomllib.loads(path.read_text(encoding="utf-8"))
+    grid_data = _table(data, "grid")
+    system_data = _table(data, "system")
+    constraint_data = _table(data, "constraints")
+    objective_data = _table(data, "objective")
+    optimizer_data = _table(data, "optimizer")
+    robustness_data = _table(data, "robustness")
+    distances = tuple(
+        float(value)
+        for value in system_data.get("plane_distances_m", [0.04, 0.05, 0.03])
+    )
+    if len(distances) != 3:
+        raise ValueError("flagship requires exactly three plane distances")
+    return FlagshipConfig(
+        name=str(data.get("name", path.stem)),
+        seed=int(data.get("seed", 20260714)),
+        grid=OpticalGridConfig(
+            shape=_int_pair(grid_data.get("shape", 32), "grid.shape"),
+            extent_m=_float_pair(grid_data.get("extent_m", 4.0e-3), "grid.extent_m"),
+            wavelength_m=float(grid_data.get("wavelength_m", 1064.0e-9)),
+        ),
+        system=FlagshipSystemConfig(
+            waist_m=float(system_data.get("waist_m", 0.55e-3)),
+            plane_distances_m=distances,
+            aperture_radius_m=float(
+                system_data.get("aperture_radius_m", 1.5e-3)
+            ),
+        ),
+        constraints=FlagshipConstraintConfig(
+            phase_bounds_rad=_float_pair(
+                constraint_data.get("phase_bounds_rad", (-math.pi, math.pi)),
+                "constraints.phase_bounds_rad",
+            ),
+            smoothing_passes=int(constraint_data.get("smoothing_passes", 1)),
+            total_variation_weight=float(
+                constraint_data.get("total_variation_weight", 1.0e-4)
+            ),
+        ),
+        objective=FlagshipObjectiveConfig(
+            intensity_weight=float(objective_data.get("intensity_weight", 0.05)),
+            worst_case_weight=float(objective_data.get("worst_case_weight", 0.5)),
+        ),
+        optimizer=FlagshipOptimizerConfig(
+            iterations=int(optimizer_data.get("iterations", 60)),
+            learning_rate=float(optimizer_data.get("learning_rate", 0.08)),
+            beta1=float(optimizer_data.get("beta1", 0.9)),
+            beta2=float(optimizer_data.get("beta2", 0.999)),
+            epsilon=float(optimizer_data.get("epsilon", 1.0e-8)),
+            initial_scale=float(optimizer_data.get("initial_scale", 0.2)),
+        ),
+        optimization_scenarios=_scenarios(
+            robustness_data.get("optimization_scenarios", [])
+        ),
+        held_out_scenarios=_scenarios(
+            robustness_data.get("held_out_scenarios", [])
+        ),
+    )
+
+
+def _scenarios(items: Any) -> tuple[PerturbationScenario, ...]:
+    if not isinstance(items, list):
+        raise ValueError("scenario sets must be arrays of inline tables")
+    scenarios = []
+    for item in items:
+        if not isinstance(item, dict) or "name" not in item or "kind" not in item:
+            raise ValueError("each scenario requires name and kind")
+        scenarios.append(
+            PerturbationScenario(
+                name=str(item["name"]),
+                kind=str(item["kind"]),
+                wavelength_scale=float(item.get("wavelength_scale", 1.0)),
+                alignment_pixels=_int_pair(
+                    item.get("alignment_pixels", (0, 0)),
+                    "alignment_pixels",
+                ),
+                phase_depth_scale=float(item.get("phase_depth_scale", 1.0)),
+                spacing_scale=float(item.get("spacing_scale", 1.0)),
+            )
+        )
+    return tuple(scenarios)
+
+
+def _table(data: dict[str, Any], name: str) -> dict[str, Any]:
+    value = data.get(name, {})
+    if not isinstance(value, dict):
+        raise ValueError(f"[{name}] must be a TOML table")
+    return value
+
+
+def _int_pair(value: Any, name: str) -> tuple[int, int]:
+    values = (value, value) if isinstance(value, int) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be an integer or two-item array")
+    return int(values[0]), int(values[1])
+
+
+def _float_pair(value: Any, name: str) -> tuple[float, float]:
+    values = (value, value) if isinstance(value, (int, float)) else value
+    if not isinstance(values, (list, tuple)) or len(values) != 2:
+        raise ValueError(f"{name} must be a number or two-item array")
+    return float(values[0]), float(values[1])

--- a/src/quantum_dynamics_lab/wave_cli.py
+++ b/src/quantum_dynamics_lab/wave_cli.py
@@ -31,6 +31,13 @@ def main(argv: list[str] | None = None) -> int:
     optimize_parser.add_argument("--out", type=Path, required=True)
     optimize_parser.add_argument("--resume", type=Path)
 
+    flagship_parser = subparsers.add_parser(
+        "flagship",
+        help="Run the robust Gaussian-to-HG10 baseline comparison",
+    )
+    flagship_parser.add_argument("config", type=Path)
+    flagship_parser.add_argument("--out", type=Path, required=True)
+
     args = parser.parse_args(argv)
     if args.command == "propagate":
         config = load_wave_config(args.config)
@@ -49,6 +56,13 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(result.out_dir)
         return 0 if result.status in {"complete", "early_stopped"} else 1
+    if args.command == "flagship":
+        from .flagship import run_flagship
+        from .flagship_config import load_flagship_config
+
+        run_flagship(load_flagship_config(args.config), args.out)
+        print(args.out)
+        return 0
     return 2
 
 

--- a/tests/test_flagship.py
+++ b/tests/test_flagship.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+import pytest
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+REFERENCE_PATH = REPOSITORY_ROOT / "benchmarks" / "reference" / "flagship_m4.json"
+sys.path.insert(0, str(REPOSITORY_ROOT))
+
+from benchmarks.reference.generate_flagship_m4 import generate_metrics
+from quantum_dynamics_lab.flagship import BASELINE_NAMES, run_flagship
+from quantum_dynamics_lab.flagship_config import load_flagship_config
+
+
+CONFIG_PATH = REPOSITORY_ROOT / "examples" / "robust_flagship.toml"
+
+
+def test_flagship_scenario_sets_and_required_baselines() -> None:
+    config = load_flagship_config(CONFIG_PATH)
+    optimization_signatures = {
+        scenario.signature for scenario in config.optimization_scenarios
+    }
+    held_signatures = {scenario.signature for scenario in config.held_out_scenarios}
+    required_kinds = {"wavelength", "alignment", "phase_depth", "plane_spacing"}
+
+    assert optimization_signatures.isdisjoint(held_signatures)
+    assert required_kinds <= {
+        scenario.kind for scenario in config.optimization_scenarios
+    }
+    assert required_kinds <= {scenario.kind for scenario in config.held_out_scenarios}
+    assert BASELINE_NAMES == (
+        "no_masks",
+        "one_optimized_mask",
+        "three_nominal_masks",
+        "three_robust_masks",
+    )
+
+
+def test_flagship_reference_is_reproducible_and_reports_all_comparisons() -> None:
+    reference = json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+    actual = generate_metrics()
+
+    assert actual["required_baselines"] == list(BASELINE_NAMES)
+    assert actual["scenario_sets_disjoint"]
+    assert set(actual["baselines"]) == set(BASELINE_NAMES)
+    for name in BASELINE_NAMES:
+        actual_baseline = actual["baselines"][name]
+        expected_baseline = reference["baselines"][name]
+        assert len(actual_baseline["held_out"]) == len(actual["held_out_scenarios"])
+        for section in ("nominal", "held_out_mean", "held_out_worst"):
+            for metric in (
+                "mode_overlap",
+                "intensity_similarity",
+                "mode_power_efficiency",
+            ):
+                assert actual_baseline[section][metric] == pytest.approx(
+                    expected_baseline[section][metric],
+                    abs=2e-10,
+                    rel=2e-10,
+                )
+    assert actual["robust_worst_case_overlap_advantage"] == pytest.approx(
+        reference["robust_worst_case_overlap_advantage"],
+        abs=2e-10,
+        rel=2e-10,
+    )
+    assert actual["robust_worst_case_overlap_advantage"] > reference[
+        "declared_limits"
+    ]["minimum_robust_worst_case_advantage"]
+
+
+def test_flagship_writes_comparison_artifacts(tmp_path: Path) -> None:
+    result = run_flagship(load_flagship_config(CONFIG_PATH), tmp_path)
+
+    assert result.metrics["robustness_claim_passed"]
+    for name in (
+        "designs.npz",
+        "environment.json",
+        "histories.json",
+        "metrics.json",
+        "report.md",
+        "resolved_config.json",
+        "scenarios.json",
+    ):
+        assert (tmp_path / name).exists()
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    for baseline in BASELINE_NAMES:
+        assert baseline in report


### PR DESCRIPTION
Closes #46

## Change

Adds the deterministic four-baseline flagship ladder: no masks, one optimized mask, three nominally optimized masks, and three masks optimized across an 11-scenario robustness ensemble. All baselines share source, HG10 target, grid, aperture, total length, constraints, optimizer semantics, metrics, and seed.

The committed optimization and held-out sets are explicitly disjoint. Both cover wavelength, alignment, phase-depth, and plane-spacing classes; held-out alignment uses diagonal directions absent from training. The runner saves designs, histories, scenarios, config, environment/provenance, metrics, and a comparison report through `wave-lab flagship`.

## Validation and evidence

- Focused flagship suite — 3 passed.
- `JAX_ENABLE_X64=1 uv run --extra jax --extra ui pytest` — 82 passed.
- No-mask nominal overlap: approximately zero (`3.995e-22`).
- One-mask nominal / held-out worst overlap: `0.608300` / `0.456924`.
- Three-nominal nominal / held-out worst overlap: `0.936511` / `0.762172`.
- Three-robust nominal / held-out worst overlap: `0.924105` / `0.781349`.
- Robust held-out worst advantage over nominal three-mask design: `0.019178`, above the committed `0.01` minimum.
- Worst held-out robust efficiency: `0.781315`.
- Regeneration is checked at `2e-10` absolute/relative tolerance.

The tradeoff is explicit: robust training improves held-out worst case but slightly lowers nominal and held-out mean performance relative to nominal three-mask optimization.

## Interpretation and compatibility

This PR establishes the Fresnel-model robustness comparison only. The report explicitly withholds the v1.0 conclusion pending independent BLAS transfer and convergence. All M3/M2/M1/quantum/CLI/dashboard regressions remain green.

This is a stacked draft PR targeting the #44 branch.