### PR TITLE
Cross-validate flagship model transfer and convergence

### DIFF
--- a/benchmarks/reference/README.md
+++ b/benchmarks/reference/README.md
@@ -79,3 +79,11 @@ JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_flag
 This reference establishes the Fresnel-model comparison only. The v1.0 model-
 transfer conclusion additionally requires the committed BLAS and convergence
 evidence.
+
+`flagship_validation_m4.json` records that second half of the M4 ladder:
+Fresnel-to-BLAS transfer, retained spectrum, and grid/padding/aperture/substep
+convergence. Regenerate it with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax python -m benchmarks.reference.generate_flagship_validation_m4
+```

--- a/benchmarks/reference/flagship_validation_m4.json
+++ b/benchmarks/reference/flagship_validation_m4.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": 1,
+  "name": "robust_gaussian_to_hg10",
+  "model_transfer_summary": {
+    "maximum_absolute_overlap_transfer_loss": 4.448768787801427e-07,
+    "maximum_absolute_efficiency_transfer_loss": 4.4395809906117023e-07,
+    "minimum_blas_retained_spectral_power": 1.0
+  },
+  "convergence_summary": {
+    "grid_finest_pair_overlap_change": 0.00643370296723933,
+    "padding_finest_pair_overlap_change": 2.11153217166693e-06,
+    "aperture_finest_pair_overlap_change": 1.881571062734011e-06,
+    "step_finest_pair_overlap_change": 0.0,
+    "boundary_power_fraction": 3.2712308056280675e-08
+  },
+  "series": {
+    "grid_overlap": [
+      0.8824403215175378,
+      0.924105464735772,
+      0.8816786330250703,
+      0.875244930057831
+    ],
+    "padding_overlap": [
+      0.924105464735772,
+      0.9241017416371153,
+      0.9240996301049437
+    ],
+    "aperture_overlap": [
+      0.9236108955553259,
+      0.924105464735772,
+      0.9240724116052675,
+      0.9240705300342048
+    ],
+    "step_overlap": [
+      0.924105464735772,
+      0.9241054647357724,
+      0.9241054647357724
+    ]
+  },
+  "trusted": true,
+  "checks": {
+    "model_transfer_overlap": true,
+    "model_transfer_efficiency": true,
+    "blas_retained_power": true,
+    "grid_convergence": true,
+    "padding_convergence": true,
+    "aperture_convergence": true,
+    "step_convergence": true,
+    "boundary_power": true
+  }
+}

--- a/benchmarks/reference/generate_flagship_validation_m4.py
+++ b/benchmarks/reference/generate_flagship_validation_m4.py
@@ -1,0 +1,33 @@
+"""Regenerate M4 model-transfer and convergence reference metrics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from quantum_dynamics_lab.flagship import run_flagship
+from quantum_dynamics_lab.flagship_config import load_flagship_config
+from quantum_dynamics_lab.flagship_validation import validate_flagship
+
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = REPOSITORY_ROOT / "examples" / "robust_flagship.toml"
+REFERENCE_PATH = Path(__file__).with_name("flagship_validation_m4.json")
+
+
+def generate_metrics() -> dict:
+    config = load_flagship_config(CONFIG_PATH)
+    flagship = run_flagship(config)
+    return validate_flagship(config, flagship).metrics
+
+
+def main() -> None:
+    REFERENCE_PATH.write_text(
+        json.dumps(generate_metrics(), indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(REFERENCE_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/flagship-model-transfer.md
+++ b/docs/flagship-model-transfer.md
@@ -1,0 +1,33 @@
+# Flagship Model Transfer and Trusted Regime
+
+The three phase masks are optimized only with differentiable Fresnel
+propagation. The committed validation re-evaluates every required baseline under
+nominal and every held-out scenario with the independently formulated NumPy
+band-limited angular-spectrum (BLAS) model. The code does not reuse the JAX
+Fresnel transfer function for that evaluation.
+
+The report records per-scenario overlap and input-referenced efficiency from
+both models, absolute transfer loss, and the minimum spectral power retained by
+BLAS. It also fixes the robust design and runs:
+
+- 24, 32, 48, and 64 sample grid studies at fixed window size;
+- 1.0×, 1.5×, and 2.0× padding at fixed sample spacing;
+- 1.2, 1.5, 1.8, and 1.95 mm aperture radii;
+- one, two, and four propagation substeps per inter-mask distance;
+- a padded-window boundary-power diagnostic.
+
+The thresholds are declared in `flagship_validation.DECLARED_LIMITS` and stored
+with every generated report. A result is trusted only if all transfer,
+retained-spectrum, convergence, and boundary checks pass. Regenerate the small
+reference with:
+
+```bash
+JAX_ENABLE_X64=1 uv run --extra jax python -m \
+  benchmarks.reference.generate_flagship_validation_m4
+```
+
+The trusted regime remains monochromatic coherent scalar free-space optics at
+the committed aperture, sampling, window, and angular content. Reduced-scale
+Maxwell/FDTD is not performed: the millimetre-scale device is outside practical
+CPU CI scope, and ADR 0004 makes independent scalar-model transfer—not optional
+full-wave simulation—the v1.0 release gate.

--- a/src/quantum_dynamics_lab/flagship_validation.py
+++ b/src/quantum_dynamics_lab/flagship_validation.py
@@ -1,0 +1,441 @@
+"""Independent model-transfer and convergence validation for the flagship."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+import json
+
+import numpy as np
+
+from .flagship import BASELINE_NAMES, FlagshipResult, run_flagship
+from .flagship_config import FlagshipConfig, PerturbationScenario
+from .objectives import intensity_similarity, mode_overlap, mode_power_efficiency
+from .optics import circular_aperture, gaussian_mode, hermite_gaussian_mode, make_optical_grid
+from .optics_propagation import (
+    angular_spectrum_retained_power,
+    propagate_angular_spectrum,
+    propagate_fresnel,
+)
+
+
+DECLARED_LIMITS = {
+    "maximum_overlap_transfer_loss": 1.0e-3,
+    "maximum_efficiency_transfer_loss": 1.0e-3,
+    "minimum_blas_retained_spectral_power": 1.0 - 1.0e-12,
+    "maximum_grid_finest_pair_overlap_change": 2.0e-2,
+    "maximum_padding_finest_pair_overlap_change": 5.0e-3,
+    "maximum_aperture_finest_pair_overlap_change": 5.0e-3,
+    "maximum_step_finest_pair_overlap_change": 1.0e-8,
+    "maximum_boundary_power_fraction": 1.0e-3,
+    "reproduction_absolute_tolerance": 2.0e-10,
+    "reproduction_relative_tolerance": 2.0e-10,
+}
+
+
+@dataclass(frozen=True)
+class FlagshipValidationResult:
+    metrics: dict[str, Any]
+
+
+def validate_flagship(
+    config: FlagshipConfig,
+    flagship: FlagshipResult | None = None,
+    out_dir: str | Path | None = None,
+) -> FlagshipValidationResult:
+    """Run model-transfer and numerical convergence on fixed optimized designs."""
+
+    if flagship is None:
+        flagship = run_flagship(config)
+    base_grid = make_optical_grid(
+        config.grid.shape,
+        config.grid.extent_m,
+        config.grid.wavelength_m,
+    )
+    source = gaussian_mode(base_grid, config.system.waist_m)
+    target = hermite_gaussian_mode(base_grid, (1, 0), config.system.waist_m)
+    nominal = PerturbationScenario(name="nominal", kind="nominal")
+    scenario_sequence = (nominal, *config.held_out_scenarios)
+    model_transfer: dict[str, Any] = {}
+    all_overlap_losses = []
+    all_efficiency_losses = []
+    all_retained = []
+    for name in BASELINE_NAMES:
+        comparisons = []
+        for scenario in scenario_sequence:
+            fresnel = _evaluate(
+                flagship.designs[name],
+                config,
+                base_grid,
+                source,
+                target,
+                scenario,
+                model="fresnel",
+            )
+            angular = _evaluate(
+                flagship.designs[name],
+                config,
+                base_grid,
+                source,
+                target,
+                scenario,
+                model="angular_spectrum",
+            )
+            overlap_loss = fresnel["mode_overlap"] - angular["mode_overlap"]
+            efficiency_loss = (
+                fresnel["mode_power_efficiency"]
+                - angular["mode_power_efficiency"]
+            )
+            all_overlap_losses.append(abs(overlap_loss))
+            all_efficiency_losses.append(abs(efficiency_loss))
+            all_retained.append(angular["minimum_retained_spectral_power"])
+            comparisons.append(
+                {
+                    "name": scenario.name,
+                    "kind": scenario.kind,
+                    "fresnel": fresnel,
+                    "angular_spectrum": angular,
+                    "overlap_transfer_loss": overlap_loss,
+                    "efficiency_transfer_loss": efficiency_loss,
+                }
+            )
+        model_transfer[name] = comparisons
+
+    robust_design = flagship.designs["three_robust_masks"]
+    grid_series = _grid_series(robust_design, config, base_grid)
+    padding_series = _padding_series(robust_design, config, base_grid)
+    aperture_series = _aperture_series(robust_design, config, base_grid)
+    step_series = _step_series(robust_design, config, base_grid)
+    boundary_fraction = padding_series[-1]["boundary_power_fraction"]
+    convergence = {
+        "grid": grid_series,
+        "padding": padding_series,
+        "aperture": aperture_series,
+        "step": step_series,
+        "grid_finest_pair_overlap_change": _finest_change(grid_series),
+        "padding_finest_pair_overlap_change": _finest_change(padding_series),
+        "aperture_finest_pair_overlap_change": _finest_change(aperture_series),
+        "step_finest_pair_overlap_change": _finest_change(step_series),
+        "boundary_power_fraction": boundary_fraction,
+    }
+    summary = {
+        "maximum_absolute_overlap_transfer_loss": max(all_overlap_losses),
+        "maximum_absolute_efficiency_transfer_loss": max(all_efficiency_losses),
+        "minimum_blas_retained_spectral_power": min(all_retained),
+    }
+    checks = {
+        "model_transfer_overlap": summary[
+            "maximum_absolute_overlap_transfer_loss"
+        ]
+        <= DECLARED_LIMITS["maximum_overlap_transfer_loss"],
+        "model_transfer_efficiency": summary[
+            "maximum_absolute_efficiency_transfer_loss"
+        ]
+        <= DECLARED_LIMITS["maximum_efficiency_transfer_loss"],
+        "blas_retained_power": summary["minimum_blas_retained_spectral_power"]
+        >= DECLARED_LIMITS["minimum_blas_retained_spectral_power"],
+        "grid_convergence": convergence["grid_finest_pair_overlap_change"]
+        <= DECLARED_LIMITS["maximum_grid_finest_pair_overlap_change"],
+        "padding_convergence": convergence["padding_finest_pair_overlap_change"]
+        <= DECLARED_LIMITS["maximum_padding_finest_pair_overlap_change"],
+        "aperture_convergence": convergence["aperture_finest_pair_overlap_change"]
+        <= DECLARED_LIMITS["maximum_aperture_finest_pair_overlap_change"],
+        "step_convergence": convergence["step_finest_pair_overlap_change"]
+        <= DECLARED_LIMITS["maximum_step_finest_pair_overlap_change"],
+        "boundary_power": boundary_fraction
+        <= DECLARED_LIMITS["maximum_boundary_power_fraction"],
+    }
+    metrics = {
+        "schema_version": 1,
+        "name": config.name,
+        "model_transfer": model_transfer,
+        "model_transfer_summary": summary,
+        "convergence": convergence,
+        "declared_limits": DECLARED_LIMITS,
+        "checks": checks,
+        "trusted": all(checks.values()),
+        "trusted_regime": (
+            "monochromatic coherent scalar free-space fields within the committed "
+            "sampling, padding, aperture, retained-spectrum, and paraxial/BLAS "
+            "transfer thresholds"
+        ),
+        "maxwell_fdtd": {
+            "performed": False,
+            "required": False,
+            "rationale": (
+                "Optional reduced-scale full-wave validation was not performed; "
+                "the millimetre-scale free-space device is outside the practical "
+                "CPU CI scope and ADR 0004 makes scalar-model transfer the release gate."
+            ),
+        },
+    }
+    result = FlagshipValidationResult(metrics=metrics)
+    if out_dir is not None:
+        _write_validation_artifacts(Path(out_dir), result)
+    return result
+
+
+def _evaluate(
+    phases: np.ndarray,
+    config: FlagshipConfig,
+    grid,
+    source: np.ndarray,
+    target: np.ndarray,
+    scenario: PerturbationScenario,
+    *,
+    model: str,
+    aperture_radius: float | None = None,
+    step_count: int = 1,
+) -> dict[str, float]:
+    aperture = circular_aperture(
+        grid,
+        config.system.aperture_radius_m if aperture_radius is None else aperture_radius,
+    )
+    scenario_grid = make_optical_grid(
+        grid.shape,
+        grid.extent,
+        grid.wavelength * scenario.wavelength_scale,
+    )
+    shifted = np.roll(
+        phases,
+        shift=scenario.alignment_pixels,
+        axis=(-2, -1),
+    ) * scenario.phase_depth_scale
+    field = source.copy()
+    retained = 1.0
+    for phase, distance in zip(
+        shifted,
+        config.system.plane_distances_m,
+        strict=True,
+    ):
+        field = field * aperture * np.exp(1j * phase)
+        substep = distance * scenario.spacing_scale / step_count
+        for _ in range(step_count):
+            if model == "fresnel":
+                field = propagate_fresnel(field, scenario_grid, substep)
+            elif model == "angular_spectrum":
+                retained = min(
+                    retained,
+                    angular_spectrum_retained_power(field, scenario_grid, substep),
+                )
+                field = propagate_angular_spectrum(field, scenario_grid, substep)
+            else:
+                raise ValueError(f"unsupported validation model: {model}")
+    power = float(np.sum(np.abs(field) ** 2) * grid.sample_area)
+    return {
+        "mode_overlap": mode_overlap(field, target, grid.sample_area),
+        "intensity_similarity": intensity_similarity(field, target, grid.sample_area),
+        "mode_power_efficiency": mode_power_efficiency(
+            field,
+            target,
+            1.0,
+            grid.sample_area,
+        ),
+        "output_power": power,
+        "minimum_retained_spectral_power": retained,
+        "boundary_power_fraction": _boundary_power_fraction(field, grid),
+    }
+
+
+def _grid_series(phases: np.ndarray, config: FlagshipConfig, base_grid) -> list[dict[str, float]]:
+    series = []
+    for size in (24, 32, 48, 64):
+        grid = make_optical_grid(size, config.grid.extent_m, config.grid.wavelength_m)
+        resized = _resample_phase_masks(phases, base_grid, grid)
+        source = gaussian_mode(grid, config.system.waist_m)
+        target = hermite_gaussian_mode(grid, (1, 0), config.system.waist_m)
+        metrics = _evaluate(
+            resized,
+            config,
+            grid,
+            source,
+            target,
+            PerturbationScenario("nominal", "nominal"),
+            model="fresnel",
+        )
+        series.append({"grid_size": float(size), **metrics})
+    return series
+
+
+def _padding_series(
+    phases: np.ndarray,
+    config: FlagshipConfig,
+    base_grid,
+) -> list[dict[str, float]]:
+    series = []
+    for factor in (1.0, 1.5, 2.0):
+        shape = tuple(int(round(value * factor)) for value in base_grid.shape)
+        extent = tuple(value * factor for value in base_grid.extent)
+        grid = make_optical_grid(shape, extent, config.grid.wavelength_m)
+        resized = _resample_phase_masks(phases, base_grid, grid)
+        source = gaussian_mode(grid, config.system.waist_m)
+        target = hermite_gaussian_mode(grid, (1, 0), config.system.waist_m)
+        metrics = _evaluate(
+            resized,
+            config,
+            grid,
+            source,
+            target,
+            PerturbationScenario("nominal", "nominal"),
+            model="fresnel",
+        )
+        series.append({"padding_factor": factor, **metrics})
+    return series
+
+
+def _aperture_series(
+    phases: np.ndarray,
+    config: FlagshipConfig,
+    grid,
+) -> list[dict[str, float]]:
+    source = gaussian_mode(grid, config.system.waist_m)
+    target = hermite_gaussian_mode(grid, (1, 0), config.system.waist_m)
+    series = []
+    for radius in (1.2e-3, 1.5e-3, 1.8e-3, 1.95e-3):
+        metrics = _evaluate(
+            phases,
+            config,
+            grid,
+            source,
+            target,
+            PerturbationScenario("nominal", "nominal"),
+            model="fresnel",
+            aperture_radius=radius,
+        )
+        series.append({"aperture_radius_m": radius, **metrics})
+    return series
+
+
+def _step_series(phases: np.ndarray, config: FlagshipConfig, grid) -> list[dict[str, float]]:
+    source = gaussian_mode(grid, config.system.waist_m)
+    target = hermite_gaussian_mode(grid, (1, 0), config.system.waist_m)
+    series = []
+    for step_count in (1, 2, 4):
+        metrics = _evaluate(
+            phases,
+            config,
+            grid,
+            source,
+            target,
+            PerturbationScenario("nominal", "nominal"),
+            model="fresnel",
+            step_count=step_count,
+        )
+        series.append({"substeps_per_plane": float(step_count), **metrics})
+    return series
+
+
+def _resample_phase_masks(phases: np.ndarray, old_grid, new_grid) -> np.ndarray:
+    if old_grid.shape == new_grid.shape and old_grid.extent == new_grid.extent:
+        return phases.copy()
+    result = []
+    for phase in phases:
+        transmission = np.exp(1j * phase)
+        intermediate = np.empty((old_grid.shape[0], new_grid.shape[1]), np.complex128)
+        for row in range(old_grid.shape[0]):
+            intermediate[row] = np.interp(
+                new_grid.x,
+                old_grid.x,
+                transmission[row].real,
+                left=1.0,
+                right=1.0,
+            ) + 1j * np.interp(
+                new_grid.x,
+                old_grid.x,
+                transmission[row].imag,
+                left=0.0,
+                right=0.0,
+            )
+        resized = np.empty(new_grid.shape, np.complex128)
+        for column in range(new_grid.shape[1]):
+            resized[:, column] = np.interp(
+                new_grid.y,
+                old_grid.y,
+                intermediate[:, column].real,
+                left=1.0,
+                right=1.0,
+            ) + 1j * np.interp(
+                new_grid.y,
+                old_grid.y,
+                intermediate[:, column].imag,
+                left=0.0,
+                right=0.0,
+            )
+        result.append(np.angle(resized))
+    return np.asarray(result, dtype=np.float64)
+
+
+def _boundary_power_fraction(field: np.ndarray, grid, width: int = 2) -> float:
+    intensity = np.abs(field) ** 2
+    mask = np.zeros(grid.shape, dtype=bool)
+    mask[:width, :] = True
+    mask[-width:, :] = True
+    mask[:, :width] = True
+    mask[:, -width:] = True
+    total = float(np.sum(intensity))
+    return 0.0 if total == 0.0 else float(np.sum(intensity[mask]) / total)
+
+
+def _finest_change(series: list[dict[str, float]]) -> float:
+    return abs(series[-1]["mode_overlap"] - series[-2]["mode_overlap"])
+
+
+def _write_validation_artifacts(
+    out_dir: Path,
+    result: FlagshipValidationResult,
+) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "validation_metrics.json").write_text(
+        json.dumps(result.metrics, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / "model_transfer_report.md").write_text(
+        _model_transfer_report(result.metrics),
+        encoding="utf-8",
+    )
+    flagship_report = out_dir / "report.md"
+    if flagship_report.exists():
+        original = flagship_report.read_text(encoding="utf-8")
+        flagship_report.write_text(
+            original
+            + "\n## Independent validation\n\n"
+            + f"Trusted: **{result.metrics['trusted']}**. See "
+            + "`model_transfer_report.md` and `validation_metrics.json` for "
+            + "the full BLAS and convergence evidence.\n",
+            encoding="utf-8",
+        )
+
+
+def _model_transfer_report(metrics: dict[str, Any]) -> str:
+    summary = metrics["model_transfer_summary"]
+    convergence = metrics["convergence"]
+    checks = "\n".join(
+        f"- {name}: {'PASS' if passed else 'FAIL'}"
+        for name, passed in metrics["checks"].items()
+    )
+    return f"""# Flagship model-transfer and convergence report
+
+Trusted: **{metrics['trusted']}**
+
+- Maximum absolute Fresnel/BLAS overlap transfer loss: {summary['maximum_absolute_overlap_transfer_loss']:.8g}
+- Maximum absolute Fresnel/BLAS efficiency transfer loss: {summary['maximum_absolute_efficiency_transfer_loss']:.8g}
+- Minimum BLAS retained spectral power: {summary['minimum_blas_retained_spectral_power']:.12f}
+- Grid finest-pair overlap change: {convergence['grid_finest_pair_overlap_change']:.8g}
+- Padding finest-pair overlap change: {convergence['padding_finest_pair_overlap_change']:.8g}
+- Aperture finest-pair overlap change: {convergence['aperture_finest_pair_overlap_change']:.8g}
+- Propagation-substep finest-pair overlap change: {convergence['step_finest_pair_overlap_change']:.8g}
+- Padded-window boundary power fraction: {convergence['boundary_power_fraction']:.8g}
+
+## Declared checks
+
+{checks}
+
+## Trusted regime
+
+{metrics['trusted_regime']}.
+
+## Full-wave disposition
+
+Maxwell/FDTD performed: **False**. {metrics['maxwell_fdtd']['rationale']}
+"""

--- a/src/quantum_dynamics_lab/wave_cli.py
+++ b/src/quantum_dynamics_lab/wave_cli.py
@@ -59,8 +59,11 @@ def main(argv: list[str] | None = None) -> int:
     if args.command == "flagship":
         from .flagship import run_flagship
         from .flagship_config import load_flagship_config
+        from .flagship_validation import validate_flagship
 
-        run_flagship(load_flagship_config(args.config), args.out)
+        config = load_flagship_config(args.config)
+        flagship = run_flagship(config, args.out)
+        validate_flagship(config, flagship, args.out)
         print(args.out)
         return 0
     return 2

--- a/tests/test_flagship_validation.py
+++ b/tests/test_flagship_validation.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+jax = pytest.importorskip("jax")
+jax.config.update("jax_enable_x64", True)
+
+from quantum_dynamics_lab.flagship import BASELINE_NAMES, run_flagship
+from quantum_dynamics_lab.flagship_config import load_flagship_config
+from quantum_dynamics_lab.flagship_validation import validate_flagship
+
+
+REPOSITORY_ROOT = Path(__file__).parents[1]
+CONFIG_PATH = REPOSITORY_ROOT / "examples" / "robust_flagship.toml"
+REFERENCE_PATH = (
+    REPOSITORY_ROOT
+    / "benchmarks"
+    / "reference"
+    / "flagship_validation_m4.json"
+)
+
+
+def test_flagship_model_transfer_and_convergence_reference(tmp_path: Path) -> None:
+    config = load_flagship_config(CONFIG_PATH)
+    flagship = run_flagship(config, tmp_path)
+    actual = validate_flagship(config, flagship, tmp_path).metrics
+    reference = json.loads(REFERENCE_PATH.read_text(encoding="utf-8"))
+    tolerance = actual["declared_limits"]
+
+    assert actual["trusted"]
+    assert all(actual["checks"].values())
+    assert actual["checks"] == reference["checks"]
+    for baseline in BASELINE_NAMES:
+        comparisons = actual["model_transfer"][baseline]
+        assert len(comparisons) == 1 + len(config.held_out_scenarios)
+        assert all("fresnel" in item and "angular_spectrum" in item for item in comparisons)
+    for key, expected in reference["model_transfer_summary"].items():
+        assert actual["model_transfer_summary"][key] == pytest.approx(
+            expected,
+            abs=tolerance["reproduction_absolute_tolerance"],
+            rel=tolerance["reproduction_relative_tolerance"],
+        )
+    convergence = actual["convergence"]
+    for key, expected in reference["convergence_summary"].items():
+        assert convergence[key] == pytest.approx(
+            expected,
+            abs=tolerance["reproduction_absolute_tolerance"],
+            rel=tolerance["reproduction_relative_tolerance"],
+        )
+    for name, key in (
+        ("grid_overlap", "grid"),
+        ("padding_overlap", "padding"),
+        ("aperture_overlap", "aperture"),
+        ("step_overlap", "step"),
+    ):
+        assert [item["mode_overlap"] for item in convergence[key]] == pytest.approx(
+            reference["series"][name],
+            abs=tolerance["reproduction_absolute_tolerance"],
+            rel=tolerance["reproduction_relative_tolerance"],
+        )
+    assert not actual["maxwell_fdtd"]["performed"]
+    assert not actual["maxwell_fdtd"]["required"]
+    assert (tmp_path / "validation_metrics.json").exists()
+    assert (tmp_path / "model_transfer_report.md").exists()
+    report = (tmp_path / "report.md").read_text(encoding="utf-8")
+    assert "Independent validation" in report
+    assert "Trusted: **True**" in report


### PR DESCRIPTION
Closes #48

## Change

Adds the independent M4 validation ladder for the fixed Fresnel-designed flagship. Every required baseline under nominal plus all eight held-out scenarios is re-evaluated with the separately formulated NumPy band-limited angular-spectrum model. The validator records per-scenario overlap/efficiency transfer loss and retained spectral power.

The robust design is also evaluated across committed grid, padding, aperture, and propagation-substep series, with a padded-window boundary-power diagnostic. `wave-lab flagship` now writes both the comparison report and integrated model-transfer/convergence artifacts.

## Validation and evidence

- Focused validation reference — 1 passed.
- `JAX_ENABLE_X64=1 uv run --extra jax --extra ui pytest` — 83 passed.
- Maximum absolute Fresnel→BLAS overlap loss: `4.4488e-7` (limit `1e-3`).
- Maximum absolute efficiency loss: `4.4396e-7` (limit `1e-3`).
- Minimum BLAS retained spectral power: `1.0` (minimum `1 - 1e-12`).
- Grid finest-pair overlap change: `0.0064337` (limit `0.02`).
- Padding finest-pair change: `2.1115e-6` (limit `0.005`).
- Aperture finest-pair change: `1.8816e-6` (limit `0.005`).
- Substep finest-pair change: `0.0` (limit `1e-8`).
- Padded boundary power fraction: `3.2712e-8` (limit `1e-3`).
- All declared checks pass without tolerance changes; deterministic reproduction uses `2e-10` absolute/relative tolerances.

## Trusted regime and full-wave disposition

The result is trusted only for the committed monochromatic coherent scalar free-space regime, sampling, padding, aperture, retained spectrum, and Fresnel/BLAS agreement. Optional reduced-scale Maxwell/FDTD was not performed because the millimetre-scale device is outside practical CPU CI scope; ADR 0004 makes independent scalar-model transfer the v1.0 gate.

## Compatibility

All flagship/M3/M2/M1/quantum/CLI/dashboard regressions remain green and generated outputs remain ignored.

This is a stacked draft PR targeting the #46 branch.