### PR TITLE
Complete wave lab v1.0 release identity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,16 @@ jobs:
         run: uv sync --dev --extra ui
       - name: Run tests
         run: uv run pytest
-      - name: Run CLI smoke experiment
+      - name: Check public CLI entrypoints
+        run: |
+          uv run wave-lab --help
+          uv run quantum-lab --help
+      - name: Run NumPy wave CLI smoke experiment
+        run: uv run wave-lab propagate examples/gaussian_lens.toml --out /tmp/wave-lab-smoke
+      - name: Run legacy quantum CLI smoke experiment
         run: uv run quantum-lab run examples/free_packet.toml --out /tmp/quantum-lab-smoke
-      - name: Check dashboard entrypoint
-        run: uv run --extra ui streamlit version
+      - name: Check dashboard startup
+        run: uv run --extra ui pytest tests/test_dashboard.py::test_streamlit_dashboard_starts_without_errors -q
 
   jax-test:
     runs-on: ubuntu-latest
@@ -35,3 +41,7 @@ jobs:
         run: uv sync --dev --extra jax
       - name: Run full suite with JAX enabled
         run: uv run --extra jax pytest
+      - name: Run differentiable optimization smoke experiment
+        run: uv run --extra jax wave-lab optimize examples/inverse_design_smoke.toml --out /tmp/inverse-design-smoke
+      - name: Regenerate the robust flagship and independent model transfer
+        run: uv run --extra jax wave-lab flagship examples/robust_flagship.toml --out /tmp/robust-flagship-smoke

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,13 +19,13 @@ direction and milestone gates; it is not a daily task list.
 
 ## Current Priority
 
-**M0 - Pivot foundation**, **M1 - Forward optics v0.2**, **M2 - Differentiable
-solver v0.3**, and **M3 - Inverse-design MVP v0.4** are complete. The current
-priority is **M4 - Robust flagship v1.0**: run the declared Gaussian-to-HG10
-baseline ladder, separate optimization and held-out perturbations, validate
-grid/padding/aperture/step convergence, and report Fresnel-to-band-limited-
-angular-spectrum transfer before completing the CLI/dashboard/documentation
-identity. Do not claim robustness from the optimization ensemble alone.
+**M0 - Pivot foundation** through **M4 - Robust flagship v1.0** are complete.
+The current priority is release maintenance: preserve the committed v1.0
+evidence, public `wave-lab` and `quantum-lab` interfaces, and NumPy/JAX/model-
+transfer regression gates. Scope post-v1 behavioral work through an issue and,
+when it changes the product boundary or scientific claims, an accepted ADR with
+matching evidence. Do not broaden the scalar-model validity claims without new
+validation.
 
 ## Project Invariants
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,107 @@
-# 2D-Quantum-Free-Particle
+# Differentiable 2D Wave Inverse-Design Lab
 
-> **Project direction:** this repository is being incrementally generalized into
-> a differentiable 2D wave inverse-design lab, with scalar photonics as the first
-> practical application. The existing quantum workflows remain supported during
-> the migration. See [ROADMAP.md](ROADMAP.md) for scope, milestones, and current
-> status.
+This repository is a reproducible 2D scalar-wave propagation and inverse-design
+laboratory. NumPy is the correctness reference; optional JAX supplies automatic
+differentiation and JIT-compiled multi-plane optimization. The v1.0 flagship is
+a robust three-plane phase-only Gaussian-to-HG10 converter evaluated under
+held-out perturbations and independently cross-checked with band-limited angular
+spectrum propagation.
 
-## 2D Quantum Dynamics Lab
+The original `quantum-lab` CLI, configs, dashboard experiments, and frozen
+quantum v0.1 regression baseline remain supported as legacy demonstrations.
+See [ROADMAP.md](ROADMAP.md), [the accepted ADRs](docs/adr/README.md), and
+[CONTRIBUTING.md](CONTRIBUTING.md) for scope and evidence rules.
+
+## Wave lab v1.0 quick start
+
+Forward scalar optics uses only the NumPy reference path:
+
+```bash
+uv sync --dev
+uv run pytest
+uv run wave-lab propagate examples/gaussian_lens.toml --out runs/gaussian-lens
+```
+
+Differentiable optimization and the full robust flagship use the optional JAX
+CPU path in 64-bit mode:
+
+```bash
+uv sync --dev --extra jax
+JAX_ENABLE_X64=1 uv run --extra jax wave-lab optimize examples/inverse_design_smoke.toml --out runs/inverse-design-smoke
+JAX_ENABLE_X64=1 uv run --extra jax wave-lab flagship examples/robust_flagship.toml --out runs/robust-flagship
+JAX_ENABLE_X64=1 uv run --extra jax pytest
+```
+
+On PowerShell, set `$env:JAX_ENABLE_X64 = "1"` before running the JAX commands.
+GPU availability is optional and is not required for correctness or CI.
+
+### Product boundary
+
+v1.0 supports monochromatic coherent scalar fields, Gaussian/Hermite-Gaussian
+and arbitrary complex inputs, lenses/apertures/phase masks, Fresnel and
+band-limited angular-spectrum propagation, normalized optical objectives,
+bounded/smoothed/TV/quantized phase constraints, restartable Adam optimization,
+robust ensembles, held-out evaluation, and provenance-rich artifacts.
+
+It does not claim polarization or vector-Maxwell accuracy, nonlinear/broadband
+or partially coherent propagation, high-index integrated-photonics validity,
+manufacturing-ready layout, or mask export.
+
+### Flagship evidence
+
+The four required comparisons use a common 1064 nm grid, aperture, 12 cm total
+length, Gaussian source, HG10 target, constraints, metrics, and seed:
+
+| Baseline | Nominal overlap | Held-out mean | Held-out worst | Worst efficiency |
+| --- | ---: | ---: | ---: | ---: |
+| No masks | ~0 | ~0 | ~0 | ~0 |
+| One optimized mask | 0.608300 | 0.583858 | 0.456924 | 0.456871 |
+| Three nominal masks | 0.936511 | 0.899484 | 0.762172 | 0.762128 |
+| Three robust masks | 0.924105 | 0.887806 | 0.781349 | 0.781315 |
+
+Optimization and held-out sets are disjoint and both cover wavelength,
+alignment, phase-depth, and plane-spacing perturbations. Robust training gains
+`0.019178` in held-out worst overlap over nominal three-mask training, while
+slightly reducing nominal and held-out mean performance; that tradeoff is part
+of the result, not hidden.
+
+The independently implemented NumPy BLAS evaluation reports maximum absolute
+Fresnel-transfer loss `4.45e-7`, minimum retained sampled spectral power `1.0`,
+grid finest-pair change `0.00643`, padding change `2.11e-6`, aperture change
+`1.88e-6`, substep change `0`, and padded boundary power `3.27e-8`. All
+predeclared gates pass. The trusted regime is limited to the committed
+monochromatic coherent scalar free-space sampling, window, aperture, and angular
+content. Optional reduced-scale Maxwell/FDTD was not performed because the
+millimetre-scale system is outside practical CPU CI scope; ADR 0004 makes
+independent scalar-model transfer the release gate.
+
+Evidence and regeneration details:
+
+- [M1 propagation validation](docs/optics-model-validation.md) and
+  [`optics_m1.json`](benchmarks/reference/optics_m1.json)
+- [M2 objectives/gradients](docs/objectives-and-gradients.md) and
+  [`jax_m2.json`](benchmarks/reference/jax_m2.json)
+- [M3 restartable optimizer](docs/inverse-design-runner.md)
+- [M4 flagship protocol](docs/flagship-experiment.md) and
+  [`flagship_m4.json`](benchmarks/reference/flagship_m4.json)
+- [M4 model transfer](docs/flagship-model-transfer.md) and
+  [`flagship_validation_m4.json`](benchmarks/reference/flagship_validation_m4.json)
+
+## Interactive dashboard
+
+```bash
+uv sync --dev --extra ui
+uv run --extra ui streamlit run apps/streamlit_dashboard.py
+```
+
+The dashboard leads with NumPy forward optics, constrained inverse design, and
+the committed validated flagship summary. Long optimization/flagship actions
+are loaded lazily and require the JAX extra. The “Legacy Quantum” workspace
+retains free-packet, barrier/Zeno, double-slit, sweep, and quantum-validation
+controls. Dashboard outputs remain under ignored `runs/dashboard/` and
+`reports/dashboard/` directories.
+
+## Preserved quantum dynamics workflows
 
 This repository now includes a maintained Python package for reproducible
 2D quantum dynamics experiments. The original C++/Python/GPU scripts remain
@@ -14,7 +109,7 @@ in place as legacy reference material from the Scientific Computing Capstone
 project, while the new `quantum-dynamics-lab` package is the recommended path
 for new runs.
 
-### Quick start with uv
+### Legacy quantum CLI
 
 ```bash
 uv sync --dev
@@ -29,7 +124,7 @@ uv run quantum-lab validate examples/validation_suite.toml --out reports/validat
 uv run quantum-lab render runs/free_packet/run.npz --out reports/free_packet
 ```
 
-### Interactive dashboard
+### Legacy dashboard interpretation
 
 Install the optional UI dependency and launch the local Streamlit research
 dashboard:
@@ -39,10 +134,10 @@ uv sync --dev --extra ui
 uv run --extra ui streamlit run apps/streamlit_dashboard.py
 ```
 
-The dashboard provides parameter controls for free-packet, barrier/Zeno, and
-double-slit experiments, a saved-frame viewer for probability density and
-phase, norm and probability diagnostics, and access to the generated NPZ and
-report artifacts. Double-slit runs compare coherent and which-path densities,
+The legacy workspace provides parameter controls for free-packet, barrier/Zeno,
+and double-slit experiments, a saved-frame viewer for probability density and
+phase, norm and probability diagnostics, and access to generated artifacts.
+Double-slit runs compare coherent and which-path densities,
 screen profiles, and a global min/max screen-profile contrast. That contrast is
 a visualization and regression diagnostic; it has not been independently
 validated as a physical interference-visibility measurement. The Zeno Sweep

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Differentiable 2D Wave Inverse-Design Lab Roadmap
 
-Last updated: 2026-07-13
+Last updated: 2026-07-14
 
 ## Direction
 
@@ -51,7 +51,7 @@ M0 Pivot foundation
 | M1 - Forward optics v0.2 | Complete | Pure propagation core plus validated scalar-optics sources, elements, Fresnel propagation, and angular-spectrum propagation |
 | M2 - Differentiable solver v0.3 | Complete | JAX parity, JIT-compatible propagation, mode-overlap objectives, and validated gradients |
 | M3 - Inverse-design MVP v0.4 | Complete | Constrained phase parameterization, regularization, optimization runner, checkpoints, and deterministic smoke optimization |
-| M4 - Robust flagship v1.0 | Planned | Robust multi-plane mode conversion, held-out perturbation results, cross-model validation, and the new CLI/dashboard identity |
+| M4 - Robust flagship v1.0 | Complete | Robust multi-plane mode conversion, disjoint held-out perturbation results, independent cross-model validation, and the wave-first CLI/dashboard identity |
 
 ### M0 - Pivot Foundation
 

--- a/apps/streamlit_dashboard.py
+++ b/apps/streamlit_dashboard.py
@@ -10,12 +10,15 @@ from quantum_dynamics_lab.dashboard import (
     DashboardParameters,
     DashboardRun,
     DashboardSweep,
+    load_flagship_dashboard_summary,
+    plot_wave_field_panels,
     experiment_summary,
     plot_diagnostic_panels,
     plot_double_slit_panels,
     plot_field_panels,
     run_dashboard_experiment,
     run_dashboard_validation,
+    run_dashboard_wave_forward,
     run_dashboard_zeno_sweep,
     timestamped_output_dir,
 )
@@ -27,39 +30,215 @@ ROOT = Path(__file__).resolve().parents[1]
 
 
 def main() -> None:
-    st.set_page_config(page_title="2D Quantum Dynamics Lab", layout="wide")
-    st.title("2D Quantum Dynamics Lab")
-    experiment_tab, sweep_tab, validation_tab = st.tabs(
-        ["Experiment", "Zeno Sweep", "Validation"]
+    st.set_page_config(page_title="Differentiable 2D Wave Lab", layout="wide")
+    st.title("Differentiable 2D Wave Inverse-Design Lab")
+    st.caption(
+        "Validated scalar free-space propagation, constrained inverse design, "
+        "and a preserved legacy quantum demonstration workspace."
+    )
+    forward_tab, design_tab, flagship_tab, quantum_tab = st.tabs(
+        ["Forward Optics", "Inverse Design", "Validated Flagship", "Legacy Quantum"]
     )
 
-    parameters, run_requested = _experiment_controls()
-    with experiment_tab:
-        if run_requested:
-            out_dir = timestamped_output_dir(ROOT / "runs" / "dashboard", parameters.name)
-            try:
-                with st.spinner("Evolving wavefunction and generating artifacts..."):
-                    st.session_state["dashboard_run"] = run_dashboard_experiment(
-                        parameters, out_dir
-                    )
-            except (OSError, RuntimeError, ValueError) as exc:
-                st.error(str(exc))
-        dashboard_run = st.session_state.get("dashboard_run")
-        if dashboard_run is None:
-            st.info("Set experiment parameters in the sidebar and run a simulation.")
-        else:
-            _show_experiment(dashboard_run)
+    with forward_tab:
+        _forward_optics_workspace()
 
-    with sweep_tab:
-        _zeno_sweep_workspace(parameters)
+    with design_tab:
+        _inverse_design_workspace()
 
-    with validation_tab:
-        _validation_workspace()
+    with flagship_tab:
+        _flagship_workspace()
+
+    with quantum_tab:
+        st.info(
+            "Legacy quantum demonstrations remain supported for compatibility and "
+            "regression coverage; their Zeno/double-slit diagnostics are not new "
+            "research validation."
+        )
+        experiment_tab, sweep_tab, validation_tab = st.tabs(
+            ["Experiment", "Zeno Sweep", "Validation"]
+        )
+
+        parameters, run_requested = _experiment_controls()
+        with experiment_tab:
+            if run_requested:
+                out_dir = timestamped_output_dir(
+                    ROOT / "runs" / "dashboard", parameters.name
+                )
+                try:
+                    with st.spinner("Evolving wavefunction and generating artifacts..."):
+                        st.session_state["dashboard_run"] = run_dashboard_experiment(
+                            parameters, out_dir
+                        )
+                except (OSError, RuntimeError, ValueError) as exc:
+                    st.error(str(exc))
+            dashboard_run = st.session_state.get("dashboard_run")
+            if dashboard_run is None:
+                st.info("Set quantum parameters in the sidebar and run a simulation.")
+            else:
+                _show_experiment(dashboard_run)
+
+        with sweep_tab:
+            _zeno_sweep_workspace(parameters)
+
+        with validation_tab:
+            _validation_workspace()
+
+
+def _forward_optics_workspace() -> None:
+    st.subheader("Scalar forward propagation")
+    st.write(
+        "Run a coherent monochromatic Gaussian/HG/array field through lenses, "
+        "apertures, phase masks, and Fresnel or BLAS propagation."
+    )
+    config_value = st.text_input(
+        "Forward config",
+        value="examples/gaussian_lens.toml",
+        key="wave_forward_config",
+    )
+    if st.button("Run forward optics", type="primary"):
+        config_path = _repository_path(config_value)
+        out_dir = timestamped_output_dir(
+            ROOT / "runs" / "dashboard" / "wave", config_path.stem
+        )
+        try:
+            with st.spinner("Propagating scalar field and saving artifacts..."):
+                st.session_state["wave_dashboard_run"] = run_dashboard_wave_forward(
+                    config_path,
+                    out_dir,
+                )
+        except (OSError, RuntimeError, ValueError) as exc:
+            st.error(str(exc))
+    dashboard_run = st.session_state.get("wave_dashboard_run")
+    if dashboard_run is None:
+        st.info("Run the committed Gaussian-through-lens example or another wave config.")
+        return
+    metrics = dashboard_run.run.metrics
+    columns = st.columns(3)
+    columns[0].metric("Input power", f"{metrics['input_power']:.8f}")
+    columns[1].metric("Final power", f"{metrics['final_power']:.8f}")
+    columns[2].metric("Efficiency", f"{metrics['power_efficiency']:.8f}")
+    plot_columns = st.columns(2)
+    for column, figure in zip(
+        plot_columns,
+        plot_wave_field_panels(dashboard_run.run),
+        strict=True,
+    ):
+        column.pyplot(figure, width="stretch")
+        plt.close(figure)
+    st.code(str(dashboard_run.run_path.relative_to(ROOT)))
+    st.download_button(
+        "Download wave_run.npz",
+        dashboard_run.run_path.read_bytes(),
+        file_name="wave_run.npz",
+        mime="application/octet-stream",
+        on_click="ignore",
+    )
+
+
+def _inverse_design_workspace() -> None:
+    st.subheader("Constrained phase-mask inverse design")
+    st.write(
+        "The deterministic Adam runner supports bounded/smoothed/TV/quantized "
+        "phase masks, restart checkpoints, early stopping, and complete provenance."
+    )
+    st.code(
+        "JAX_ENABLE_X64=1 uv run --extra jax wave-lab optimize "
+        "examples/inverse_design_smoke.toml --out runs/inverse-design-smoke"
+    )
+    if st.button("Run inverse-design smoke"):
+        try:
+            from quantum_dynamics_lab.design_config import load_inverse_design_config
+            from quantum_dynamics_lab.optimization import run_inverse_design
+
+            out_dir = timestamped_output_dir(
+                ROOT / "runs" / "dashboard" / "design", "inverse-design-smoke"
+            )
+            with st.spinner("Compiling and optimizing on the available JAX device..."):
+                result = run_inverse_design(
+                    load_inverse_design_config(ROOT / "examples/inverse_design_smoke.toml"),
+                    out_dir,
+                )
+            st.session_state["design_dashboard_result"] = result
+        except (ImportError, OSError, RuntimeError, ValueError) as exc:
+            st.error(f"Install the JAX extra and enable x64 before optimizing: {exc}")
+    result = st.session_state.get("design_dashboard_result")
+    if result is not None:
+        columns = st.columns(3)
+        columns[0].metric(
+            "Initial overlap", f"{result.metrics['initial']['mode_overlap']:.6f}"
+        )
+        columns[1].metric(
+            "Best overlap", f"{result.metrics['best']['mode_overlap']:.6f}"
+        )
+        columns[2].metric(
+            "Improvement", f"{result.metrics['mode_overlap_improvement']:.6f}"
+        )
+        st.code(str(result.out_dir.relative_to(ROOT)))
+
+
+def _flagship_workspace() -> None:
+    st.subheader("Validated robust Gaussian-to-HG10 flagship")
+    reference = load_flagship_dashboard_summary(ROOT)
+    rows = []
+    for name, baseline in reference.comparison["baselines"].items():
+        rows.append(
+            {
+                "baseline": name,
+                "nominal_overlap": baseline["nominal"]["mode_overlap"],
+                "held_mean_overlap": baseline["held_out_mean"]["mode_overlap"],
+                "held_worst_overlap": baseline["held_out_worst"]["mode_overlap"],
+                "held_worst_efficiency": baseline["held_out_worst"][
+                    "mode_power_efficiency"
+                ],
+            }
+        )
+    st.dataframe(rows, width="stretch", hide_index=True)
+    validation_columns = st.columns(3)
+    validation_columns[0].metric(
+        "Robust worst-case advantage",
+        f"{reference.comparison['robust_worst_case_overlap_advantage']:.6f}",
+    )
+    validation_columns[1].metric(
+        "Max Fresnel→BLAS loss",
+        f"{reference.validation['model_transfer_summary']['maximum_absolute_overlap_transfer_loss']:.2e}",
+    )
+    validation_columns[2].metric(
+        "Trusted validation", "PASS" if reference.validation["trusted"] else "FAIL"
+    )
+    st.caption(
+        "Optimization and held-out scenarios are disjoint. The robust design "
+        "improves held-out worst case while slightly reducing nominal/mean performance."
+    )
+    if st.button("Regenerate flagship and validation"):
+        try:
+            from quantum_dynamics_lab.flagship import run_flagship
+            from quantum_dynamics_lab.flagship_config import load_flagship_config
+            from quantum_dynamics_lab.flagship_validation import validate_flagship
+
+            config = load_flagship_config(ROOT / "examples/robust_flagship.toml")
+            out_dir = timestamped_output_dir(
+                ROOT / "reports" / "dashboard" / "flagship", "robust-flagship"
+            )
+            with st.spinner("Optimizing all baselines and running BLAS validation..."):
+                result = run_flagship(config, out_dir)
+                validate_flagship(config, result, out_dir)
+            st.session_state["flagship_dashboard_out"] = out_dir
+        except (ImportError, OSError, RuntimeError, ValueError) as exc:
+            st.error(f"Install the JAX extra and enable x64 before regenerating: {exc}")
+    flagship_out = st.session_state.get("flagship_dashboard_out")
+    if flagship_out is not None:
+        st.success(f"Flagship artifacts written to {flagship_out.relative_to(ROOT)}")
+
+
+def _repository_path(value: str) -> Path:
+    path = Path(value)
+    return path if path.is_absolute() else ROOT / path
 
 
 def _experiment_controls() -> tuple[DashboardParameters, bool]:
     with st.sidebar:
-        st.header("Experiment setup")
+        st.header("Legacy quantum setup")
         mode = st.segmented_control(
             "Experiment",
             ["Free packet", "Barrier / Zeno", "Double slit"],

--- a/docs/v1-release.md
+++ b/docs/v1-release.md
@@ -1,0 +1,43 @@
+# v1.0 Release Evidence
+
+The v1.0 release completes M0 through M4 without removing the legacy quantum
+surface. Its release claim is deliberately narrow: a differentiable
+monochromatic coherent scalar Fresnel model designed a three-plane phase-only
+Gaussian-to-HG10 converter whose held-out worst overlap exceeds the nominally
+optimized three-plane design, and the fixed device transfers to an independently
+implemented band-limited angular-spectrum evaluator inside declared numerical
+limits.
+
+## Gate summary
+
+- M0: quantum v0.1 references preserve free, barrier, measured-barrier, and
+  double-slit behavior without treating their current diagnostics as new
+  physical validation.
+- M1: the pure propagation core, quantum adapter, scalar sources/elements,
+  analytic Gaussian/lens checks, conservation/reversibility, convergence, and
+  Fresnel/BLAS reference regime pass.
+- M2: JAX x64 parity, fixed-shape JIT scan, normalized objectives, centered
+  directional gradient checks, and a compiled CPU update pass.
+- M3: bounded/smoothed/TV/quantized constraints, deterministic Adam improvement,
+  early stopping, best checkpoints, fingerprinted restart equivalence, and
+  complete artifacts pass.
+- M4: all four baselines, disjoint robust/held-out sets, worst-case improvement,
+  BLAS transfer, retained spectrum, grid/padding/aperture/substep convergence,
+  boundary power, CLI, dashboard, documentation, and CI pass.
+
+The small committed references live in `benchmarks/reference/`; regeneration
+code is adjacent. Generated fields, histories, checkpoints, and reports remain
+ignored under `runs/` and `reports/`.
+
+## Compatibility and limitations
+
+`wave-lab` is the primary v1.0 CLI. `quantum-lab` remains available with the
+same commands, committed configs, artifact schema, and dashboard workflows.
+The Python import namespace and distribution name remain unchanged to avoid a
+compatibility-breaking rename in this release.
+
+No vector-Maxwell, polarization, broadband, nonlinear, partially coherent,
+high-index integrated-photonics, or manufacturing-readiness claim is made.
+Maxwell/FDTD remains optional and was not computationally proportionate for the
+millimetre-scale CPU-CI flagship; the accepted release gate is independent
+scalar-model transfer under ADR 0004.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "quantum-dynamics-lab"
-version = "0.1.0"
-description = "Reproducible 2D quantum dynamics experiments with a NumPy split-step solver."
+version = "1.0.0"
+description = "Differentiable 2D scalar-wave propagation and inverse design with preserved quantum demos."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { file = "LICENSE" }

--- a/src/quantum_dynamics_lab/__init__.py
+++ b/src/quantum_dynamics_lab/__init__.py
@@ -1,8 +1,8 @@
-"""2D Quantum Dynamics Lab."""
+"""Differentiable 2D wave inverse-design lab with preserved quantum demos."""
 
 from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version("quantum-dynamics-lab")
 except PackageNotFoundError:  # pragma: no cover - editable tree fallback
-    __version__ = "0.1.0"
+    __version__ = "1.0.0"

--- a/src/quantum_dynamics_lab/dashboard.py
+++ b/src/quantum_dynamics_lab/dashboard.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+import json
 import re
 
 import matplotlib
@@ -28,6 +29,9 @@ from .config import (
 from .experiments import ExperimentResult, run_experiment
 from .render import render_comparison, render_run
 from .validation import load_validation_config, run_validation
+from .wave_artifacts import save_wave_run
+from .wave_config import load_wave_config
+from .wave_experiments import WaveRun, run_wave_propagation
 
 
 @dataclass(frozen=True)
@@ -73,6 +77,88 @@ class DashboardSweep:
     run_paths: tuple[Path, ...]
     rows: tuple[dict[str, float], ...]
     outputs: dict[str, Path]
+
+
+@dataclass(frozen=True)
+class WaveDashboardRun:
+    run: WaveRun
+    run_path: Path
+
+
+@dataclass(frozen=True)
+class FlagshipDashboardSummary:
+    comparison: dict[str, Any]
+    validation: dict[str, Any]
+
+
+def run_dashboard_wave_forward(
+    config_path: str | Path,
+    out_dir: str | Path,
+) -> WaveDashboardRun:
+    """Run a NumPy forward-optics config without importing optional JAX."""
+
+    run = run_wave_propagation(load_wave_config(config_path))
+    return WaveDashboardRun(run=run, run_path=save_wave_run(run, out_dir))
+
+
+def plot_wave_field_panels(run: WaveRun) -> tuple[Figure, Figure]:
+    """Plot input/output intensity and phase for dashboard display."""
+
+    figures = []
+    extent = [
+        float(run.grid.x[0]),
+        float(run.grid.x[-1]),
+        float(run.grid.y[0]),
+        float(run.grid.y[-1]),
+    ]
+    for label, field in (
+        ("Input field", run.input_field),
+        ("Output field", run.final_field),
+    ):
+        figure, axes = plt.subplots(1, 2, figsize=(8.0, 3.2), constrained_layout=True)
+        intensity = axes[0].imshow(
+            np.abs(field) ** 2,
+            origin="lower",
+            extent=extent,
+            cmap="magma",
+        )
+        axes[0].set_title(f"{label} intensity")
+        figure.colorbar(intensity, ax=axes[0], shrink=0.8)
+        phase = axes[1].imshow(
+            np.angle(field),
+            origin="lower",
+            extent=extent,
+            cmap="twilight",
+            vmin=-np.pi,
+            vmax=np.pi,
+        )
+        axes[1].set_title(f"{label} phase")
+        figure.colorbar(phase, ax=axes[1], shrink=0.8)
+        for axis in axes:
+            axis.set_xlabel("x")
+            axis.set_ylabel("y")
+        figures.append(figure)
+    return tuple(figures)
+
+
+def load_flagship_dashboard_summary(
+    repository_root: str | Path | None = None,
+) -> FlagshipDashboardSummary:
+    """Load committed M4 metrics for read-only UI use without JAX."""
+
+    root = (
+        Path(repository_root)
+        if repository_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    reference = root / "benchmarks" / "reference"
+    comparison = json.loads(
+        (reference / "flagship_m4.json").read_text(encoding="utf-8")
+    )
+    validation = json.loads(
+        (reference / "flagship_validation_m4.json").read_text(encoding="utf-8")
+    )
+    return FlagshipDashboardSummary(comparison=comparison, validation=validation)
 
 
 def build_experiment_config(parameters: DashboardParameters) -> ExperimentConfig:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -10,10 +10,13 @@ from quantum_dynamics_lab.dashboard import (
     DashboardParameters,
     build_experiment_config,
     experiment_summary,
+    load_flagship_dashboard_summary,
     plot_diagnostic_panels,
     plot_double_slit_panels,
     plot_field_panels,
+    plot_wave_field_panels,
     run_dashboard_experiment,
+    run_dashboard_wave_forward,
     run_dashboard_zeno_sweep,
 )
 
@@ -181,6 +184,25 @@ def test_dashboard_zeno_sweep_writes_comparison_artifacts(tmp_path) -> None:
     assert sweep.outputs["html_report"].exists()
 
 
+def test_dashboard_wave_forward_and_flagship_reference(tmp_path) -> None:
+    repository_root = Path(__file__).parents[1]
+    wave = run_dashboard_wave_forward(
+        repository_root / "examples" / "gaussian_lens.toml",
+        tmp_path / "wave",
+    )
+    figures = plot_wave_field_panels(wave.run)
+    reference = load_flagship_dashboard_summary(repository_root)
+
+    assert wave.run_path.exists()
+    assert wave.run.metrics["power_efficiency"] == pytest.approx(1.0, abs=1e-13)
+    assert len(figures) == 2
+    assert all(len(figure.axes) == 4 for figure in figures)
+    assert reference.comparison["robustness_claim_passed"]
+    assert reference.validation["trusted"]
+    for figure in figures:
+        plt.close(figure)
+
+
 def test_streamlit_dashboard_starts_without_errors() -> None:
     pytest.importorskip("streamlit")
     from streamlit.testing.v1 import AppTest
@@ -189,4 +211,10 @@ def test_streamlit_dashboard_starts_without_errors() -> None:
     app = AppTest.from_file(str(app_path), default_timeout=10).run()
 
     assert not app.exception
-    assert app.title[0].value == "2D Quantum Dynamics Lab"
+    assert app.title[0].value == "Differentiable 2D Wave Inverse-Design Lab"
+    assert [tab.label for tab in app.tabs[:4]] == [
+        "Forward Optics",
+        "Inverse Design",
+        "Validated Flagship",
+        "Legacy Quantum",
+    ]

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+from quantum_dynamics_lab import __version__
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_v1_package_and_public_entrypoints_are_declared() -> None:
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]
+
+    assert project["version"] == "1.0.0"
+    assert __version__ == "1.0.0"
+    assert project["scripts"] == {
+        "quantum-lab": "quantum_dynamics_lab.cli:main",
+        "wave-lab": "quantum_dynamics_lab.wave_cli:main",
+    }
+
+
+def test_m4_release_identity_and_evidence_are_durable() -> None:
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    roadmap = (ROOT / "ROADMAP.md").read_text(encoding="utf-8")
+
+    assert readme.startswith("# Differentiable 2D Wave Inverse-Design Lab")
+    assert "`quantum-lab`" in readme
+    assert "| M4 - Robust flagship v1.0 | Complete |" in roadmap
+    assert (ROOT / "benchmarks/reference/flagship_m4.json").is_file()
+    assert (ROOT / "benchmarks/reference/flagship_validation_m4.json").is_file()
+    assert (ROOT / "docs/v1-release.md").is_file()

--- a/uv.lock
+++ b/uv.lock
@@ -1337,7 +1337,7 @@ wheels = [
 
 [[package]]
 name = "quantum-dynamics-lab"
-version = "0.1.0"
+version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib" },


### PR DESCRIPTION
Closes #50

## Outcome

Completes the v1.0 product identity after the M4 flagship and independent model-transfer work in the stacked parent PR:

- leads the Streamlit dashboard with NumPy forward optics, constrained inverse design, and the committed validated flagship;
- keeps every legacy quantum dashboard workflow under an explicitly preserved workspace;
- updates package metadata to 1.0.0 and makes the README wave-first without changing the distribution or import namespace;
- marks M4 complete in ROADMAP.md and records the durable release gates and limitations;
- extends CI across both public CLIs, forward-wave and legacy-quantum smokes, dashboard startup, JAX optimization, and full flagship/BLAS regeneration.

## Validation

- `uv run pytest` — 86 passed
- `uv build` — sdist and wheel built at 1.0.0
- `uv run wave-lab --help`
- `uv run quantum-lab --help`
- `uv run wave-lab propagate examples/gaussian_lens.toml --out runs/release-smoke-wave`
- `uv run quantum-lab run examples/free_packet.toml --out runs/release-smoke-quantum`
- `uv run --extra ui pytest tests/test_dashboard.py::test_streamlit_dashboard_starts_without_errors -q`
- `JAX_ENABLE_X64=1 uv run --extra jax wave-lab optimize examples/inverse_design_smoke.toml --out runs/release-smoke-optimize`
- `JAX_ENABLE_X64=1 uv run --extra jax wave-lab flagship examples/robust_flagship.toml --out runs/release-smoke-flagship`
- `git diff --check`

## Compatibility and scientific scope

`quantum-lab`, committed quantum configs, artifact behavior, regression references, and dashboard workflows remain supported. The v1.0 claim stays limited to monochromatic coherent scalar free-space optics in the committed trusted regime. No vector-Maxwell, polarization, broadband, nonlinear, high-index integrated-photonics, manufacturing, or independent physical-validation claim is added.